### PR TITLE
Add skeleton class TileFileCache

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
 Python HiPS package documentation
 #################################
 
-.. attention::
+.. note::
 
     This package is being developed as a Google Summer of Code 2017 project. The progress 
     of this package will be updated on this `blog <https://adl1995.github.io>`_ and the student's

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
 Python HiPS package documentation
 #################################
 
-.. note::
+.. attention::
 
     This package is being developed as a Google Summer of Code 2017 project. The progress 
     of this package will be updated on this `blog <https://adl1995.github.io>`_ and the student's

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,8 +4,11 @@
 Python HiPS package documentation
 #################################
 
-.. warning::
+.. info::
 
+    This package is being developed as a Google Summer of Code 2017 project. The progress 
+    of this package will be updated on this [blog](https://adl1995.github.io) and the student's
+    application can be found [here](https://github.com/adl1995/HIPS-to-Py/blob/master/documents/application.md).
     This ``hips`` package is in a very early stage of development.
     We started to work on it in June 2017 and expect to have a first v0.1 release in summer 2017.
     That said, please have a look and try to use it for your applications.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,11 +4,11 @@
 Python HiPS package documentation
 #################################
 
-.. attention::
+.. info::
 
     This package is being developed as a Google Summer of Code 2017 project. The progress 
-    of this package will be updated on this `blog <https://adl1995.github.io>`_ and the student's
-    application can be found `here <https://github.com/adl1995/HIPS-to-Py/blob/master/documents/application.md>`_.
+    of this package will be updated on this [blog](https://adl1995.github.io) and the student's
+    application can be found [here](https://github.com/adl1995/HIPS-to-Py/blob/master/documents/application.md).
     This ``hips`` package is in a very early stage of development.
     We started to work on it in June 2017 and expect to have a first v0.1 release in summer 2017.
     That said, please have a look and try to use it for your applications.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,11 +4,8 @@
 Python HiPS package documentation
 #################################
 
-.. info::
+.. warning::
 
-    This package is being developed as a Google Summer of Code 2017 project. The progress 
-    of this package will be updated on this [blog](https://adl1995.github.io) and the student's
-    application can be found [here](https://github.com/adl1995/HIPS-to-Py/blob/master/documents/application.md).
     This ``hips`` package is in a very early stage of development.
     We started to work on it in June 2017 and expect to have a first v0.1 release in summer 2017.
     That said, please have a look and try to use it for your applications.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,11 +4,11 @@
 Python HiPS package documentation
 #################################
 
-.. info::
+.. attention::
 
     This package is being developed as a Google Summer of Code 2017 project. The progress 
-    of this package will be updated on this [blog](https://adl1995.github.io) and the student's
-    application can be found [here](https://github.com/adl1995/HIPS-to-Py/blob/master/documents/application.md).
+    of this package will be updated on this `blog <https://adl1995.github.io>`_ and the student's
+    application can be found `here <https://github.com/adl1995/HIPS-to-Py/blob/master/documents/application.md>`_.
     This ``hips`` package is in a very early stage of development.
     We started to work on it in June 2017 and expect to have a first v0.1 release in summer 2017.
     That said, please have a look and try to use it for your applications.

--- a/hips/tiles/tilefilecache.py
+++ b/hips/tiles/tilefilecache.py
@@ -1,0 +1,17 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This file provides methods for reading data from the hips-extra repository and
+fetching tiles from remote servers (like CDS) into the local tile cache.
+"""
+
+
+class TileFileCache:
+
+    def __init__(self, directory):
+        self.directory = directory
+
+    def read_file_properties(self):
+        return
+
+    def load_tiles(self):
+        return


### PR DESCRIPTION
This class will provide functionality such as reading data from the `hips-extra` repository and
fetching tiles from remote servers (like CDS) into the local tile cache.