### PR TITLE
Add scikit-image as dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
-        - CONDA_DEPENDENCIES='healpy reproject matplotlib'
+        - CONDA_DEPENDENCIES='healpy scikit-image reproject matplotlib'
         - PIP_DEPENDENCIES=''
         - CONDA_CHANNELS='conda-forge astropy-ci-extras astropy openastronomy'
         - SETUP_XVFB=True
@@ -55,7 +55,7 @@ matrix:
         # Check that install / tests work with minimal required dependencies
         - os: linux
           env: SETUP_CMD='test'
-               CONDA_DEPENDENCIES='healpy'
+               CONDA_DEPENDENCIES='healpy scikit-image'
 
         # Try MacOS X
         - os: osx

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,9 +31,6 @@ More:
 * HiPS page at CDS: http://aladin.u-strasbg.fr/hips/ (contains links to HiPS paper and available data)
 * Small example HiPS datasets we use for testing and docs examples: https://github.com/hipspy/hips-extra
 
-User documentation
-==================
-
 .. toctree::
    :maxdepth: 1
    :caption: User documentation

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,7 +20,8 @@ The ``hips`` package has the following requirements:
 * Python 3.6 or later!
 * `Numpy`_ 1.11 or later
 * `Astropy`_ 1.2 or later
-* `Healpy`_ 1.10 or later
+* `Healpy`_ 1.9 or later OK. (Don't know for older versions.)
+* `scikit-image`_ 0.12 or later OK. (Don't know for older versions.)
 
 In addition, the following packages are needed for optional functionality:
 

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -1,3 +1,4 @@
 .. _matplotlib: https://matplotlib.org
 .. _Numpy: https://www.numpy.org
 .. _Healpy: https://healpy.readthedocs.io
+.. _scikit-image: http://scikit-image.org

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,7 @@ install_requires = [
     # https://readthedocs.org/projects/hips/builds/5483435/
     # So for now, only require 1.9
     'healpy>=1.9',
+    'scikit-image',
 ]
 
 extras_require = dict(


### PR DESCRIPTION
As discussed offline, at least for now we'll use `scikit-image` for tile drawing. So I'm adding it as a dependency here in this PR. If this dependency is an issue for some users, we can always spend the effort to replace it just by scipy or pure Numpy later.