### PR TITLE
Update dependencies and CI settings

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -3,10 +3,6 @@ name: hips
 channels:
     - conda-forge
     - astropy
-    # added because it has healpy for Python 3.6:
-    # https://anaconda.org/OpenAstronomy/healpy
-    # which at this time the other channels don't have
-    - openastronomy
 
 dependencies:
     # TODO: change to Python 3.6 once it's supported:
@@ -14,8 +10,6 @@ dependencies:
     - python=3.5
     - numpy
     - astropy
-    # TODO: no Python 3.6 package for healpy available yet
-    # See https://readthedocs.org/projects/hips/builds/5476419/
     - healpy
     - reproject
     - matplotlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - PYTHON_VERSION=3.5
+        - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'
@@ -63,7 +63,7 @@ matrix:
 
         # Try older Numpy versions
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
+          env: NUMPY_VERSION=1.11
 
         # Try numpy pre-release
         - os: linux

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,8 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
-minversion = 2.8
+[tool:pytest]
+minversion = 3.0
 norecursedirs = build docs/_build
 doctest_plus = enabled
 

--- a/setup.py
+++ b/setup.py
@@ -97,9 +97,6 @@ package_info['package_data'][PACKAGENAME].extend(c_files)
 install_requires = [
     'numpy>=1.11',
     'astropy>=1.3',
-    # No healpy package for 1.10 available yet, leading to this error:
-    # https://readthedocs.org/projects/hips/builds/5483435/
-    # So for now, only require 1.9
     'healpy>=1.9',
     'scikit-image',
 ]
@@ -112,7 +109,7 @@ extras_require = dict(
     develop=[
         'matplotlib>=2.0',
         'reproject>=0.3.1',
-        'pytest>=2.8',
+        'pytest>=3.0',
         'mypy>=0.501',
     ],
 )


### PR DESCRIPTION
Now that healpy 1.10 is available for Python 3.6 on conda-forge (which we use for testing on travis-ci), see https://github.com/conda-forge/healpy-feedstock/pull/4, I'd like to try and update our CI from Python 3.5 to 3.6

This pull request:
- [x] Updates travis-ci builds from Python 3.5 to 3.6
- [x] Updates Pytest requirement from 2.8 to 3.0
