### PR TITLE
JPEG I/O library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
-        - CONDA_DEPENDENCIES='healpy scikit-image reproject matplotlib'
+        - CONDA_DEPENDENCIES='healpy scikit-image Pillow reproject matplotlib'
         - PIP_DEPENDENCIES=''
-        - CONDA_CHANNELS='conda-forge astropy-ci-extras astropy openastronomy'
+        - CONDA_CHANNELS='conda-forge astropy-ci-extras astropy'
         - SETUP_XVFB=True
         - DEBUG=True
         - ASTROPY_USE_SYSTEM_PYTEST=1
@@ -55,7 +55,7 @@ matrix:
         # Check that install / tests work with minimal required dependencies
         - os: linux
           env: SETUP_CMD='test'
-               CONDA_DEPENDENCIES='healpy scikit-image'
+               CONDA_DEPENDENCIES='healpy scikit-image Pillow'
 
         # Try MacOS X
         - os: osx

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,4 +2,7 @@ Reference/API
 =============
 
 .. automodapi:: hips
+    :no-inheritance-diagram:
+
 .. automodapi:: hips.utils
+    :no-inheritance-diagram:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,12 +20,14 @@ The ``hips`` package has the following requirements:
 * Python 3.6 or later!
 * `Numpy`_ 1.11 or later
 * `Astropy`_ 1.2 or later
-* `Healpy`_ 1.9 or later OK. (Don't know for older versions.)
-* `scikit-image`_ 0.12 or later OK. (Don't know for older versions.)
+* `Healpy`_ 1.9 or later. (Older versions could work, but aren't tested.)
+* `scikit-image`_ 0.12 or later. (Older versions could work, but aren't tested.)
+* `Pillow`_ 4.0 or later. (Older versions could work, but aren't tested.)
+  Pillow is the friendly Python Imaging Library (``PIL``) fork, for JPEG and PNG tile I/O.
 
 In addition, the following packages are needed for optional functionality:
 
-* `Matplotlib`_ 2.0 or later
+* `Matplotlib`_ 2.0 or later. Used for plotting in examples.
 
 .. note::
 

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -2,3 +2,4 @@
 .. _Numpy: https://www.numpy.org
 .. _Healpy: https://healpy.readthedocs.io
 .. _scikit-image: http://scikit-image.org
+.. _Pillow: https://python-pillow.org/

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ install_requires = [
     'astropy>=1.3',
     'healpy>=1.9',
     'scikit-image',
+    'Pillow',
 ]
 
 extras_require = dict(


### PR DESCRIPTION
In #24 is using PIL/Pillow to read JPEG tiles. This is a reminder issue that we need to declare and document this dependency (in `setup.py`, `travis.yml`, the package install instructions).
