### PR TITLE
Add documentation on HIPS_EXTRA environment variable

### DIFF
--- a/docs/develop.rst
+++ b/docs/develop.rst
@@ -6,6 +6,13 @@
 Develop
 *******
 
+To run tests accessing files from `hips-extra <https://github.com/hipspy/hips-extra>`_
+repository, users must have it cloned on their system, otherwise some test cases
+will be skipped. This contains tiles from different HiPS surveys which are used
+by the drawing module. After this, the ``HIPS_EXTRA`` environment variable must
+be set up on their system. On UNIX operating systems, this can be set using
+``export HIPS_EXTRA=path/to/hips-extra``.
+
 Want to contribute to the ``hips`` package?
 
 Great! Talk to us by filing a Github issue any time

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -80,6 +80,10 @@ To check if there are any issues with your installation, you can run the tests:
 
     python -c 'import hips; hips.test()'
 
+.. note::
+
+    For more information, see the :ref:`develop` page.
+
 Development version
 ===================
 


### PR DESCRIPTION
This pull request addresses issue #5.  It adds documentation on how to set up the `HIPS_EXTRA` environment variable.