### PR TITLE
Move hips package from Python 3.5 to 3.6

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -5,9 +5,7 @@ channels:
     - astropy
 
 dependencies:
-    # TODO: change to Python 3.6 once it's supported:
-    # https://github.com/rtfd/readthedocs.org/issues/2584#issuecomment-304366679
-    - python=3.5
+    - python=3.6
     - numpy
     - astropy
     - healpy

--- a/hips/utils/wcs.py
+++ b/hips/utils/wcs.py
@@ -102,13 +102,13 @@ class WCSGeometry:
         w = WCS(naxis=2)
 
         if coordsys == 'CEL':
-            w.wcs.ctype[0] = 'RA---{}'.format(projection)
-            w.wcs.ctype[1] = 'DEC--{}'.format(projection)
+            w.wcs.ctype[0] = f'RA---{projection}'
+            w.wcs.ctype[1] = f'DEC--{projection}'
             w.wcs.crval[0] = skydir.icrs.ra.deg
             w.wcs.crval[1] = skydir.icrs.dec.deg
         elif coordsys == 'GAL':
-            w.wcs.ctype[0] = 'GLON-{}'.format(projection)
-            w.wcs.ctype[1] = 'GLAT-{}'.format(projection)
+            w.wcs.ctype[0] = f'GLON-{projection}'
+            w.wcs.ctype[1] = f'GLAT-{projection}'
             w.wcs.crval[0] = skydir.galactic.l.deg
             w.wcs.crval[1] = skydir.galactic.b.deg
         else:


### PR DESCRIPTION
Like I've mentioned in a note at https://hips.readthedocs.io/en/latest/installation.html I would suggest to only support Python 3.6+ for the hips package, i.e. to drop Python 3.5 support.

@tboch or anyone - if you think it's a bad idea and we should support Python 3.5, please comment.
This is more of a "nice to be able to use the latest features as a developer", there is nothing in Python 3.6 that we absolutely need, we can support 3.5.

For now, I'm holding off on this change because: 
- healpy packages for Python 3.6 are missing on conda-forge, i.e. we can't switch travis-ci to Python 3.6 yet.
- readthedocs doesn't support Python 3.6 yet (at least they didn't 2 weeks ago, should be resolved soon).

So this is a reminder issue for myself, for now assigned to the v0.2 milestone.
