### PR TITLE
Improve HiPS tile I/O

### DIFF
--- a/hips/tiles/surveys.py
+++ b/hips/tiles/surveys.py
@@ -65,8 +65,8 @@ class HipsSurveyProperties:
             URL containing HiPS properties
         """
 
-        response = urllib.request.urlopen(url).read()
-        text = response.decode('utf-8')
+        with urllib.request.urlopen(url) as response:
+            text = response.read().decode('utf-8')
         return cls.parse(text)
 
     @classmethod
@@ -194,8 +194,8 @@ class HipsSurveyPropertiesList:
             HiPS list URL
         """
         url = url or cls.DEFAULT_URL
-        response = urllib.request.urlopen(url).read()
-        text = response.decode('utf-8', errors='ignore')
+        with urllib.request.urlopen(url) as response:
+            text = response.read().decode('utf-8', errors='ignore')
         return cls.parse(text)
 
     @classmethod

--- a/hips/tiles/tile.py
+++ b/hips/tiles/tile.py
@@ -150,15 +150,10 @@ class HipsTile:
         url : `str`
             URL containing HiPS tile
         """
-        raw_image = BytesIO(urllib.request.urlopen(url).read())
-        if meta.file_format == 'fits':
-            hdu_list = fits.open(raw_image)
-            data = hdu_list[0].data
-            header = hdu_list[0].header
-            return cls(meta, data, header)
-        else:
-            data = np.array(Image.open(raw_image))
-            return cls(meta, data)
+        with urllib.request.urlopen(url) as response:
+            raw_data = BytesIO(response.read())
+
+        return cls._from_raw_data(meta, raw_data)
 
     @classmethod
     def read(cls, meta: HipsTileMeta, filename: str = None) -> 'HipsTile':
@@ -172,16 +167,27 @@ class HipsTile:
             File path to store a HiPS tile
         """
         path = Path(filename) if filename else meta.full_path
+        with path.open(mode='rb') as fh:
+            raw_data = BytesIO(fh.read())
 
+        return cls._from_raw_data(meta, raw_data)
+
+    @classmethod
+    def _from_raw_data(cls, meta: HipsTileMeta, raw_data: BytesIO) -> 'HipsTile':
         if meta.file_format == 'fits':
-            with fits.open(str(path)) as hdu_list:
+            with fits.open(raw_data) as hdu_list:
                 data = hdu_list[0].data
                 header = hdu_list[0].header
             return cls(meta, data, header)
-        else:
-            image = Image.open(str(path))
-            data = np.array(image)
+        elif meta.file_format == 'jpg':
+            with Image.open(raw_data) as image:
+                data = np.array(image)
             return cls(meta, data)
+        elif meta.file_format == 'png':
+            raise NotImplementedError()
+        else:
+            raise ValueError(f'Tile file format not supported: {meta.file_format}. '
+                             'Supported formats: fits, jpg, png')
 
     def write(self, filename: str = None) -> None:
         """Write HiPS tile by a given filename.
@@ -192,10 +198,16 @@ class HipsTile:
             Name of the file
         """
         path = Path(filename) if filename else self.meta.full_path
+        file_format = self.meta.file_format
 
-        if self.meta.file_format == 'fits':
+        if file_format == 'fits':
             hdu = fits.PrimaryHDU(self.data, header=self.header)
             hdu.writeto(str(path))
-        else:
+        elif file_format == 'jpg':
             image = Image.fromarray(self.data)
             image.save(str(path))
+        elif file_format == 'png':
+            raise NotImplementedError()
+        else:
+            raise ValueError(f'Tile file format not supported: {meta.file_format}. '
+                             'Supported formats: fits, jpg, png')


### PR DESCRIPTION
I would like to propose this solution to address #42 : suppress the warnings from invalid FITS tiles.

Since this is a "known issue" (or "known feature" if you like) for the FITS tiles from CDS, and every user will get one of these warnings per tile they fetch or read on the console, and there's nothing they can / should do about it except to ignore it, I think it is appropriate to suppress these warnings.

I'm not an expert on Python warnings, but I think / hope that this will have little other effect than suppressing the warnings we want to suppress, and to keep other warnings / errors intact.

@tboch - Assigning to you for review.

@adl1995 - I've also cleaned up the I/O functions a bit to:
* always use `with` statements to read / fetch, to avoid leaving open filehandles around
* removed the code duplication in FITS tile read and fetch by always reading into a `BytesIO` and then doing the "decoding" in a `_from_raw_data` method.
* Added PNG as a third case and put NotImplementedError for now, and raise ValueError if not one of the three formats we can handle. I don't know yet if the code to handle JPG and PNG will be identical or different, if yes we could combine these two cases again via `elif file_format in {'jpg', 'png'}`, keeping the `else ValueError` part to give a better error message in case a format we don't support appears.