### PR TITLE
Add test for PNG tiles

### DIFF
--- a/hips/draw/tests/test_simple.py
+++ b/hips/draw/tests/test_simple.py
@@ -15,13 +15,13 @@ def get_test_tiles():
     tile1 = HipsTile.read(
         meta=HipsTileMeta(order=3, ipix=450, file_format='fits', frame=hips_survey.astropy_frame,
                           tile_width=512),
-        filename=get_hips_extra_file('datasets/samples/DSS2Red/Norder3/Dir0/Npix450.fits'),
+        full_path=get_hips_extra_file('datasets/samples/DSS2Red/Norder3/Dir0/Npix450.fits'),
     )
 
     tile2 = HipsTile.read(
         meta=HipsTileMeta(order=3, ipix=451, file_format='fits', frame=hips_survey.astropy_frame,
                           tile_width=512),
-        filename=get_hips_extra_file('datasets/samples/DSS2Red/Norder3/Dir0/Npix451.fits'),
+        full_path=get_hips_extra_file('datasets/samples/DSS2Red/Norder3/Dir0/Npix451.fits'),
     )
 
     return [tile1, tile2]

--- a/hips/tiles/tests/test_tile.py
+++ b/hips/tiles/tests/test_tile.py
@@ -43,6 +43,20 @@ class TestHipsTile:
         # print((tile == tile2).all())
         # assert tile == tile2
 
+    @remote_data
+    def test_fetch_read_write_png(self, tmpdir):
+        meta = HipsTileMeta(order=6, ipix=463, file_format='png')
+        url = 'http://alasky.unistra.fr/2MASS6X/2MASS6X_H/Norder6/Dir0/Npix463.png'
+        tile = HipsTile.fetch(meta, url)
+
+        assert tile.data.shape == (512, 512, 4)
+        assert_equal(tile.data[510][5:7], [[17, 17, 17, 255], [18, 18, 18, 255]])
+
+        filename = str(tmpdir / 'Npix463.png')
+        tile.write(filename)
+        tile2 = HipsTile.read(meta, filename=filename)
+
+        assert tile == tile2
 
 class TestHipsTileMeta:
     @classmethod

--- a/hips/tiles/tile.py
+++ b/hips/tiles/tile.py
@@ -189,15 +189,13 @@ class HipsTile:
                     data = hdu_list[0].data
                     header = hdu_list[0].header
             return cls(meta, data, header)
-        elif meta.file_format == 'jpg':
+        elif meta.file_format in {'jpg', 'png'}:
             with Image.open(raw_data) as image:
                 data = np.array(image)
             return cls(meta, data)
-        elif meta.file_format == 'png':
-            raise NotImplementedError()
         else:
             raise ValueError(f'Tile file format not supported: {meta.file_format}. '
-                             'Supported formats: fits, jpg, png')
+                              'Supported formats: fits, jpg, png')
 
     def write(self, filename: str = None) -> None:
         """Write HiPS tile by a given filename.
@@ -216,11 +214,9 @@ class HipsTile:
                 warnings.simplefilter('ignore', VerifyWarning)
                 hdu = fits.PrimaryHDU(self.data, header=self.header)
                 hdu.writeto(str(path))
-        elif file_format == 'jpg':
+        elif file_format in {'jpg', 'png'}:
             image = Image.fromarray(self.data)
             image.save(str(path))
-        elif file_format == 'png':
-            raise NotImplementedError()
         else:
             raise ValueError(f'Tile file format not supported: {meta.file_format}. '
-                             'Supported formats: fits, jpg, png')
+                              'Supported formats: fits, jpg, png')

--- a/hips/tiles/tile.py
+++ b/hips/tiles/tile.py
@@ -159,17 +159,17 @@ class HipsTile:
         return cls._from_raw_data(meta, raw_data)
 
     @classmethod
-    def read(cls, meta: HipsTileMeta, filename: str = None) -> 'HipsTile':
+    def read(cls, meta: HipsTileMeta, full_path: str = None) -> 'HipsTile':
         """Read HiPS tile data from a directory and load into memory (`HipsTile`).
 
         Parameters
         ----------
         meta : `HipsTileMeta`
             Metadata of HiPS tile
-        filename : `str`
+        full_path : `str`
             File path to store a HiPS tile
         """
-        path = Path(filename) if filename else meta.full_path
+        path = Path(full_path) or meta.full_path
         with path.open(mode='rb') as fh:
             raw_data = BytesIO(fh.read())
 
@@ -197,15 +197,15 @@ class HipsTile:
             raise ValueError(f'Tile file format not supported: {meta.file_format}. '
                               'Supported formats: fits, jpg, png')
 
-    def write(self, filename: str = None) -> None:
+    def write(self, full_path: str = None) -> None:
         """Write HiPS tile by a given filename.
 
         Parameters
         ----------
-        filename : `str`
+        full_path : `str`
             Name of the file
         """
-        path = Path(filename) if filename else self.meta.full_path
+        path = Path(full_path) or meta.full_path
         file_format = self.meta.file_format
 
         if file_format == 'fits':
@@ -218,5 +218,5 @@ class HipsTile:
             image = Image.fromarray(self.data)
             image.save(str(path))
         else:
-            raise ValueError(f'Tile file format not supported: {meta.file_format}. '
-                              'Supported formats: fits, jpg, png')
+            raise ValueError(f'Tile file format not supported: {file_format}. '
+                              'Supported formats: fits, jpg, png')  # pragma: no cover


### PR DESCRIPTION
This PR adds a test case for PNG tiles. The same code for jpg tiles is used for png.