### PR TITLE
Reformat SimpleTilePainter class

### DIFF
--- a/docs/plot_fits.py
+++ b/docs/plot_fits.py
@@ -6,7 +6,6 @@ from astropy.visualization.mpl_normalize import simple_norm
 from hips import HipsSurveyProperties
 from hips import make_sky_image
 from hips.utils import WCSGeometry
-import numpy as np
 url = 'http://alasky.unistra.fr/DSS/DSS2Merged/properties'
 hips_survey = HipsSurveyProperties.fetch(url)
 geometry = WCSGeometry.create_simple(
@@ -14,7 +13,7 @@ geometry = WCSGeometry.create_simple(
     width=2000, height=1000, fov="3 deg",
     coordsys='galactic', projection='AIT'
 )
-data = make_sky_image(geometry=geometry, hips_survey=hips_survey, tile_format='fits')
+image = make_sky_image(geometry=geometry, hips_survey=hips_survey, tile_format='fits')
 ax = plt.subplot(projection=geometry.wcs)
-norm = simple_norm(data, 'sqrt')
-ax.imshow(data, origin='lower', norm=norm, cmap='gray')
+norm = simple_norm(image, 'sqrt')
+ax.imshow(image, origin='lower', norm=norm, cmap='gray')

--- a/hips/draw/simple.py
+++ b/hips/draw/simple.py
@@ -1,61 +1,30 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """HiPS tile drawing -- simple method."""
-from typing import Generator, Any
 import numpy as np
+from typing import Tuple
 from astropy.wcs.utils import proj_plane_pixel_scales
 from skimage.transform import ProjectiveTransform, warp
 from ..tiles import HipsSurveyProperties, HipsTile, HipsTileMeta
-from ..utils import WCSGeometry, compute_healpix_pixel_indices
+from ..utils import WCSGeometry, compute_healpix_pixel_indices, get_hips_order_for_resolution
+
 
 __all__ = [
-    'draw_sky_image',
     'make_sky_image',
     'SimpleTilePainter',
-    'compute_matching_hips_order'
+
 ]
 
 __doctest_skip__ = [
-    'compute_matching_hips_order',
+    'SimpleTilePainter'
 ]
 
 
-# TODO: Fix type annotation issue
-def draw_sky_image(geometry: WCSGeometry, tiles: Generator[HipsTile, Any, Any],
-                   hips_survey: HipsSurveyProperties, tile_format: str) -> np.ndarray:
+class SimpleTilePainter:
     """Draw sky image using the simple and quick method.
 
-    Parameters
-    ----------
-    geometry : `~hips.utils.WCSGeometry`
-        An object of WCSGeometry
-    tiles : List[HipsTile]
-        A list of HipsTile
-    hips_survey : `~hips.HipsSurveyProperties`
-        HiPS survey properties
-    tile_format : `str`
-        Format of HiPS tile
-
-    Returns
-    -------
-    np.ndarray
-        Returns a numpy array containing all HiPS tiles projected onto it
-    """
-    if tile_format == 'jpg':
-        shape = (geometry.shape.height, geometry.shape.width, 3)
-    elif tile_format == 'png':
-        shape = (geometry.shape.height, geometry.shape.width, 4)
-    else:
-        shape = (geometry.shape.height, geometry.shape.width)
-    image = np.zeros(shape)
-    for tile in tiles:
-        painter = SimpleTilePainter(geometry, hips_survey, tile)
-        image += painter.warp_image()
-    return image
-
-
-class SimpleTilePainter:
-    """Paint a single tile using a simple projective transformation method.
-    The algorithm implemented is described here: :ref:`drawing_algo`.
+    Paint HiPS tiles onto an all-sky image using a simple projective
+    transformation method. The algorithm implemented is described
+    here: :ref:`drawing_algo`.
 
     Parameters
     ----------
@@ -63,95 +32,14 @@ class SimpleTilePainter:
         An object of WCSGeometry
     hips_survey : `~hips.HipsSurveyProperties`
         HiPS survey properties
-    tile : `HipsTile`
-       An object of HipsTile
-    """
-
-    def __init__(self, geometry: WCSGeometry, hips_survey: HipsSurveyProperties, tile: HipsTile) -> None:
-        self.geometry = geometry
-        self.hips_survey = hips_survey
-        self.tile = tile
-
-    @property
-    def dst(self) -> np.ndarray:
-        """Destination array for projective transform"""
-        width = self.hips_survey.tile_width
-        return np.array(
-            [[width - 1, 0],
-             [width - 1, width - 1],
-             [0, width - 1],
-             [0, 0]],
-        )
-
-    @property
-    def projection(self) -> ProjectiveTransform:
-        """Estimate projective transformation on a HiPS tile"""
-        corners = self.tile.meta.skycoord_corners.to_pixel(self.geometry.wcs)
-        src = np.array(corners).T.reshape((4, 2))
-        dst = self.dst
-        pt = ProjectiveTransform()
-        pt.estimate(src, dst)
-        return pt
-
-    def warp_image(self) -> np.ndarray:
-        """Warp a HiPS tile and a sky image"""
-        return warp(
-            self.tile.data,
-            self.projection,
-            output_shape=self.geometry.shape,
-            preserve_range=True,
-        )
-
-
-def fetch_tiles(healpix_pixel_indices: np.ndarray, order: int,
-                hips_survey: HipsSurveyProperties, tile_format: str) -> 'HipsTile':
-    """Fetch HiPS tiles from a remote URL.
-
-    Parameters
-    ----------
-    healpix_pixel_indices : np.ndarray
-        A list of HEALPix pixel indices
-    order : int
-        Order of the HEALPix map
-    hips_survey : HipsSurveyProperties
-        An object of HipsSurveyProperties
     tile_format : `str`
         Format of HiPS tile
-
-    Returns
-    -------
-    'HipsTile'
-        Returns an object of HipsTile
-    """
-    for healpix_pixel_index in healpix_pixel_indices:
-        tile_meta = HipsTileMeta(
-            order=order,
-            ipix=healpix_pixel_index,
-            frame=hips_survey.astropy_frame,
-            file_format=tile_format,
-        )
-        tile = HipsTile.fetch(tile_meta, hips_survey.tile_access_url(order=order, ipix=healpix_pixel_index) + tile_meta.filename)
-        yield tile
-
-
-def compute_matching_hips_order(geometry: WCSGeometry, hips_survey: HipsSurveyProperties) -> int:
-    """Compute HiPS tile order matching a given image pixel size.
-
-    Parameters
-    ----------
-    geometry : WCSGeometry
-        Geometry of the output image
-    hips_survey : HipsSurveyProperties
-        An object of HipsSurveyProperties
-
-    Returns
-    -------
-    'int'
-        Returns HiPS order
 
     Examples
     --------
-    >>> from hips.draw import compute_matching_hips_order
+    >>> from hips.utils import WCSGeometry
+    >>> from hips.draw import SimpleTilePainter
+    >>> from hips.tiles import HipsSurveyProperties
     >>> from astropy.coordinates import SkyCoord
     >>> url = 'http://alasky.unistra.fr/DSS/DSS2Merged/properties'
     >>> hips_survey = HipsSurveyProperties.fetch(url)
@@ -160,35 +48,119 @@ def compute_matching_hips_order(geometry: WCSGeometry, hips_survey: HipsSurveyPr
     ...     width=2000, height=1000, fov="3 deg",
     ...     coordsys='icrs', projection='AIT'
     ... )
-    >>> compute_matching_hips_order(geometry, hips_survey)
+    >>> painter = SimpleTilePainter(geometry, hips_survey, 'fits')
+    >>> painter.draw_hips_order
     7
+    >>> painter.run()
+    >>> painter.image.shape
+    (1000, 2000)
     """
 
-    # Sky image angular resolution (pixel size in degree)
-    resolution = np.min(proj_plane_pixel_scales(geometry.wcs))
-    desired_order = _get_hips_order_for_resolution(hips_survey.tile_width, resolution)
-    # Return the desired order, or the highest resolution available.
-    # Note that HiPS never has resolution less than 3,
-    # and that limit is handled in _get_hips_order_for_resolution
-    return np.min([desired_order, hips_survey.hips_order])
+    def __init__(self, geometry: WCSGeometry, hips_survey: HipsSurveyProperties, tile_format: str) -> None:
+        self.geometry = geometry
+        self.hips_survey = hips_survey
+        self.tile_format = tile_format
+        self._tiles = None
 
+    @property
+    def draw_hips_order(self) -> int:
+        """Compute HiPS tile order matching a given image pixel size."""
+        # Sky image angular resolution (pixel size in degrees)
+        resolution = np.min(proj_plane_pixel_scales(self.geometry.wcs))
+        desired_order = get_hips_order_for_resolution(self.hips_survey.tile_width, resolution)
+        # Return the desired order, or the highest resolution available.
+        # Note that HiPS never has resolution less than 3,
+        # and that limit is handled in _get_hips_order_for_resolution
+        return np.min([desired_order, self.hips_survey.hips_order])
 
-def _get_hips_order_for_resolution(tile_width, resolution):
-    """Finding the best HiPS order by looping through all possible options."""
-    tile_order = np.log2(tile_width)
-    full_sphere_area = 4 * np.pi * np.square(180 / np.pi)
-    # 29 is the maximum order supported by healpy and 3 is the minimum order
-    for candidate_tile_order in range(3, 29 + 1):
-        tile_resolution = np.sqrt(full_sphere_area / 12 / 4 ** (candidate_tile_order + tile_order))
-        # Finding the smaller tile order with a resolution equal or better than geometric resolution
-        if tile_resolution <= resolution:
-            break
+    @property
+    def tile_indices(self):
+        """Get list of index values for HiPS tiles."""
+        return compute_healpix_pixel_indices(
+            wcs_geometry=self.geometry,
+            order=self.draw_hips_order,
+            healpix_frame=self.hips_survey.astropy_frame,
+        )
 
-    return candidate_tile_order
+    @property
+    def dst(self) -> np.ndarray:
+        """Destination array for projective transform."""
+        width = self.hips_survey.tile_width
+        return np.array(
+            [[width - 1, 0],
+             [width - 1, width - 1],
+             [0, width - 1],
+             [0, 0]],
+        )
+
+    def projection(self, tile: HipsTile) -> ProjectiveTransform:
+        """Estimate projective transformation on a HiPS tile."""
+        corners = tile.meta.skycoord_corners.to_pixel(self.geometry.wcs)
+        src = np.array(corners).T.reshape((4, 2))
+        dst = self.dst
+        pt = ProjectiveTransform()
+        pt.estimate(src, dst)
+        return pt
+
+    def _fetch_tiles(self) -> 'HipsTile':
+        """Generator function to fetch HiPS tiles from a remote URL."""
+        for healpix_pixel_index in self.tile_indices:
+            tile_meta = HipsTileMeta(
+                order=self.draw_hips_order,
+                ipix=healpix_pixel_index,
+                frame=self.hips_survey.astropy_frame,
+                file_format=self.tile_format,
+            )
+            url = self.hips_survey.tile_access_url(order=self.draw_hips_order, ipix=healpix_pixel_index) + tile_meta.filename
+            tile = HipsTile.fetch(tile_meta, url)
+            yield tile
+
+    @property
+    def tiles(self):
+        if self._tiles is None:
+            self._tiles = list(self._fetch_tiles())
+        return self._tiles
+
+    @property
+    def shape(self) -> Tuple[int]:
+        """Shape of the output image.
+
+        The shape will be two dimensional in case of FITS file format,
+        three dimensions (RGB) in case of JPG, and four channels (RGBA)
+        in case of PNG tile. We follow the same axis order and coordinate
+        conventions that are used by others for grayscale and RGB images.
+        """
+        if self.tile_format == 'jpg':
+            return self.geometry.shape.height, self.geometry.shape.width, 3
+        elif self.tile_format == 'png':
+            return self.geometry.shape.height, self.geometry.shape.width, 4
+        else:
+            return self.geometry.shape.height, self.geometry.shape.width
+
+    def warp_image(self, tile: HipsTile) -> np.ndarray:
+        """Warp a HiPS tile and a sky image."""
+        return warp(
+            tile.data,
+            self.projection(tile),
+            output_shape=self.geometry.shape,
+            preserve_range=True,
+        )
+
+    def draw_tiles(self):
+        """Draw HiPS tiles onto an empty image."""
+        image = np.zeros(self.shape)
+        for tile in self.tiles:
+            image += self.warp_image(tile)
+        return image
+
+    def run(self) -> None:
+        """Run all steps of the naive algorithm."""
+        self.image = self.draw_tiles()
 
 
 def make_sky_image(geometry: WCSGeometry, hips_survey: HipsSurveyProperties, tile_format: str) -> np.ndarray:
     """Make sky image: fetch tiles and draw.
+
     The example for this can be found on the :ref:`gs` page.
 
     Parameters
@@ -202,18 +174,11 @@ def make_sky_image(geometry: WCSGeometry, hips_survey: HipsSurveyProperties, til
 
     Returns
     -------
-    data : `~numpy.ndarray`
+    image : `~numpy.ndarray`
         Output image pixels
     """
-    order = compute_matching_hips_order(geometry, hips_survey)
-    healpix_pixel_indices = compute_healpix_pixel_indices(
-        wcs_geometry=geometry,
-        order=order,
-        healpix_frame=hips_survey.astropy_frame,
-    )
-    # TODO: this isn't a good API. Will become better when we have a cache.
-    tiles = fetch_tiles(healpix_pixel_indices, order, hips_survey, tile_format)
 
-    image_data = draw_sky_image(geometry, tiles, hips_survey, tile_format)
+    painter = SimpleTilePainter(geometry, hips_survey, tile_format)
+    painter.run()
 
-    return image_data
+    return painter.image

--- a/hips/draw/tests/test_simple.py
+++ b/hips/draw/tests/test_simple.py
@@ -1,102 +1,76 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 import numpy as np
-import healpy as hp
-from astropy.coordinates import SkyCoord
 from numpy.testing import assert_allclose
+from astropy.coordinates import SkyCoord
 from astropy.tests.helper import remote_data
-from ..simple import make_sky_image, draw_sky_image, compute_matching_hips_order, _get_hips_order_for_resolution
-from ...tiles import HipsSurveyProperties, HipsTileMeta, HipsTile
-from ...utils import WCSGeometry
-from ...utils.testing import get_hips_extra_file, make_test_wcs_geometry, requires_hips_extra
+from ...tiles import HipsSurveyProperties
+from ..simple import make_sky_image, SimpleTilePainter
+from ...utils.wcs import WCSGeometry
+from ...utils.testing import make_test_wcs_geometry, requires_hips_extra
 
-
-def get_test_tiles(file_format, survey, order, ipix_list):
-    filename = get_hips_extra_file('datasets/samples/' + survey + '/properties')
-    hips_survey = HipsSurveyProperties.read(filename)
-
-    tiles = []
-    for ipix in ipix_list:
-        tiles.append(HipsTile.read(
-            meta=HipsTileMeta(order=order, ipix=ipix, file_format=file_format, frame=hips_survey.astropy_frame),
-            full_path=get_hips_extra_file('datasets/samples/' + survey + hips_survey.tile_path(order=order, ipix=ipix, tile_format=file_format)),
-        ))
-
-    return tiles
-
-
-draw_sky_image_pars = [
-    dict(file_format='fits', shape=(1000, 2000), survey='DSS2Red', data_1=2866.0101409848185,
-         data_2=2563.6916727348043, data_sum=4575235421.512643, order=3, ipix_list=[450, 451]),
-    dict(file_format='jpg', shape=(1000, 2000, 3), survey='DSS2Red', data_1=[13.040878, 13.040878, 13.040878],
-         data_2=[17.235874, 17.235874, 17.235874], data_sum=243177268.56158745, order=3, ipix_list=[450, 451]),
-    dict(file_format='png', shape=(1000, 2000, 4), survey='AKARI-FIS', data_1=[254., 254., 254., 255.],
-         data_2=[254., 254., 254., 255.], data_sum=946809963.7487414, order=3, ipix_list=[450, 451])
+make_sky_image_pars = [
+    dict(file_format='fits', shape=(1000, 2000), url='http://alasky.unistra.fr/DSS/DSS2Merged/properties',
+         data_1=2213.30874796, data_2=2296.93885940, data_sum=8757489268.044867),
+    dict(file_format='jpg', shape=(1000, 2000, 3), url='https://raw.githubusercontent.com/hipspy/hips-extra/master/datasets/samples/FermiColor/properties',
+         data_1=[145.388459, 98.579295, 49.792577], data_2=[146.197811, 99.531895, 56.889927], data_sum=813159920.0305891),
+    dict(file_format='png', shape=(1000, 2000, 4), url='https://raw.githubusercontent.com/hipspy/hips-extra/master/datasets/samples/AKARI-FIS/properties',
+         data_1=[249.064796, 237.805612, 190.408181, 255.], data_2=[249.013527, 238.79403, 195.793398, 255.], data_sum=1645783166.1630714)
 ]
 
 
 @remote_data
-@requires_hips_extra()
-@pytest.mark.parametrize('pars', draw_sky_image_pars)
-def test_draw_sky_image(pars):
+@pytest.mark.parametrize('pars', make_sky_image_pars)
+def test_make_sky_image(pars):
+    hips_survey = HipsSurveyProperties.fetch(url=pars['url'])
     geometry = make_test_wcs_geometry(case=2)
-    tiles = get_test_tiles(file_format=pars['file_format'], survey=pars['survey'], order=pars['order'], ipix_list=pars['ipix_list'])
-    url = 'https://raw.githubusercontent.com/hipspy/hips-extra/master/datasets/samples/' + pars['survey'] + '/properties'
-    hips_survey = HipsSurveyProperties.fetch(url)
-
-    data = draw_sky_image(geometry=geometry, tiles=tiles, hips_survey=hips_survey, tile_format=pars['file_format'])
-
-    assert data.shape == pars['shape']
-    assert data.dtype == np.float64
-    assert_allclose(np.sum(data), pars['data_sum'])
-    assert_allclose(data[400, 500], pars['data_1'])
-    assert_allclose(data[400, 501], pars['data_2'])
+    image = make_sky_image(geometry=geometry, hips_survey=hips_survey, tile_format=pars['file_format'])
+    assert image.shape == pars['shape']
+    assert image.dtype == np.float64
+    assert_allclose(np.sum(image), pars['data_sum'])
+    assert_allclose(image[200, 994], pars['data_1'])
+    assert_allclose(image[200, 995], pars['data_2'])
 
 
 @remote_data
-def test_make_sky_image():
-    # The same example is used in the high level docs getting started page
-    url = 'http://alasky.unistra.fr/DSS/DSS2Merged/properties'
-    hips_survey = HipsSurveyProperties.fetch(url)
-    geometry = make_test_wcs_geometry(case=2)
-    data = make_sky_image(geometry=geometry, hips_survey=hips_survey, tile_format='fits')
-    assert data.shape == geometry.shape
-    assert data.dtype == np.float64
+class TestSimpleTilePainter:
+    @classmethod
+    def setup_class(cls):
+        url = 'http://alasky.unistra.fr/DSS/DSS2Merged/properties'
+        cls.hips_survey = HipsSurveyProperties.fetch(url)
+        cls.geometry = WCSGeometry.create_simple(
+            skydir=SkyCoord(0, 0, unit='deg', frame='icrs'),
+            width=2000, height=1000, fov="3 deg",
+            coordsys='icrs', projection='AIT'
+        )
+        cls.simple_tile_painter = SimpleTilePainter(cls.geometry, cls.hips_survey, 'fits')
 
-    assert_allclose(np.sum(data), 8757489268.044867)
-    assert_allclose(data[200, 994], 2213.30874796)
-    assert_allclose(data[200, 995], 2296.93885940)
+    def test_draw_hips_order(self):
+        assert self.simple_tile_painter.draw_hips_order == 7
 
-hips_order_pars = [
-    dict(order=7, fov="3 deg"),
-    dict(order=5, fov="10 deg"),
-    dict(order=4, fov="15 deg"),
-]
+    def test_shape(self):
+        assert self.simple_tile_painter.shape == (1000, 2000)
 
+    def test_tile_indices(self):
+        assert list(self.simple_tile_painter.tile_indices)[:4] == [69623, 69627, 69628, 69629]
 
-@requires_hips_extra()
-@pytest.mark.parametrize('pars', hips_order_pars)
-def test_compute_matching_hips_order(pars):
-    full_path = get_hips_extra_file('datasets/samples/2MASS6XH/properties')
-    hips_survey = HipsSurveyProperties.read(filename=full_path)
-    geometry = WCSGeometry.create_simple(
-        skydir=SkyCoord(0, 0, unit='deg', frame='icrs'),
-        width=2000, height=1000, fov=pars['fov'],
-        coordsys='icrs', projection='AIT'
-    )
-    assert compute_matching_hips_order(geometry, hips_survey) == pars['order']
+    draw_hips_order_pars = [
+        dict(order=7, fov="3 deg"),
+        dict(order=5, fov="10 deg"),
+        dict(order=4, fov="15 deg"),
+    ]
 
-get_hips_order_for_resolution_pars = [
-    dict(tile_width=512, resolution=0.01232, resolution_res=0.06395791924665553, order=4),
-    dict(tile_width=256, resolution=0.0016022, resolution_res=0.003997369952915971, order=8),
-    dict(tile_width=128, resolution=0.00009032, resolution_res=0.00012491781102862408, order=13),
-]
+    @requires_hips_extra()
+    @pytest.mark.parametrize('pars', draw_hips_order_pars)
+    def test_compute_matching_hips_order(self, pars):
+        geometry = WCSGeometry.create_simple(
+            skydir=SkyCoord(0, 0, unit='deg', frame='icrs'),
+            width=2000, height=1000, fov=pars['fov'],
+            coordsys='icrs', projection='AIT'
+        )
+        simple_tile_painter = SimpleTilePainter(geometry, self.hips_survey, 'fits')
+        assert simple_tile_painter.draw_hips_order == pars['order']
 
-
-@pytest.mark.parametrize('pars', get_hips_order_for_resolution_pars)
-def test_get_hips_order_for_resolution(pars):
-    hips_order = _get_hips_order_for_resolution(pars['tile_width'], pars['resolution'])
-    assert hips_order == pars['order']
-    hips_resolution = hp.nside2resol(hp.order2nside(hips_order))
-    assert_allclose(hips_resolution, pars['resolution_res'])
-# TODO: add tests for SimpleTilePainter with asserts on the intermediate computed things.
+    def test_run(self):
+        self.simple_tile_painter.run()
+        assert_allclose(self.simple_tile_painter.image[200, 994], 2120.9609175)

--- a/hips/utils/tests/test_healpix.py
+++ b/hips/utils/tests/test_healpix.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.coordinates import SkyCoord
 import healpy as hp
-from ..healpix import boundaries, compute_healpix_pixel_indices
+from ..healpix import boundaries, compute_healpix_pixel_indices, get_hips_order_for_resolution
 from ..testing import make_test_wcs_geometry
 
 
@@ -33,3 +33,17 @@ def test_wcs_healpix_pixel_indices(pars):
     geometry = make_test_wcs_geometry(case=2)
     healpix_pixel_indices = compute_healpix_pixel_indices(geometry, order=3, healpix_frame=pars['frame'])
     assert list(healpix_pixel_indices) == pars['ipix']
+
+hips_order_for_resolution_pars = [
+    dict(tile_width=512, resolution=0.01232, resolution_res=0.06395791924665553, order=4),
+    dict(tile_width=256, resolution=0.0016022, resolution_res=0.003997369952915971, order=8),
+    dict(tile_width=128, resolution=0.00009032, resolution_res=0.00012491781102862408, order=13),
+]
+
+
+@pytest.mark.parametrize('pars', hips_order_for_resolution_pars)
+def test_get_hips_order_for_resolution(pars):
+    hips_order = get_hips_order_for_resolution(pars['tile_width'], pars['resolution'])
+    assert hips_order == pars['order']
+    hips_resolution = hp.nside2resol(hp.order2nside(hips_order))
+    assert_allclose(hips_resolution, pars['resolution_res'])


### PR DESCRIPTION
As discussed in issue #57, I have reformatted the `SimpleTilePainter` class. I'm aware this still needs some changes, but this will provide us with a working ground. For now, I have commented out the `test_draw_sky_image` function as it is not currently usable.

@cdeil @tboch Please provide feedback on what needs to be changed.