### PR TITLE
Misc changes / cleanup before v0.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,9 @@
-0.1 (unreleased)
-----------------
+0.1
+---
 
-- Set up initial Python package [#1]
+This first version of the hips package was released on July 15, 2017.
+It contains a first implementation to fetch and draw tiles.
+
+The ``hips`` package started as a project developed as part of
+Google summer of code 2017, i.e. planning in early 2017 and
+coding in June 2017.

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -1,0 +1,54 @@
+.. include:: references.txt
+
+.. _about:
+
+*****
+About
+*****
+
+Description
+===========
+
+HiPS (Hierarchical Progressive Surveys) is a way to store large
+astronomical survey sky image and catalog datasets on servers (such as `HiPS at CDS`_),
+that allows clients to efficiently fetch only the image tiles or catalog parts
+for a given region of the sky they are interested in.
+Similar to Google maps, but for astronomy (see the `HiPS paper`_).
+
+This is a Python package to fetch and draw HiPS data.
+
+It was just started in summer of 2017 and isn't stable or feature complete yet.
+Feedback and contributions welcome!
+
+Links
+=====
+
+* Code : https://github.com/hipspy/hips
+* Docs : https://hips.readthedocs.io
+* Contributors : https://github.com/hipspy/hips/graphs/contributors
+* Releases: https://pypi.python.org/pypi/hips
+
+Other resources
+===============
+
+* GSoC 2017 blog by Adeel: https://adl1995.github.io
+* `HiPS at CDS`_ (contains a list and preview of available HiPS data)
+* `HiPS paper`_
+* A Jupyter widget for Aladin Lite: https://github.com/cds-astro/ipyaladin
+* Small example HiPS datasets we use for testing and docs examples: https://github.com/hipspy/hips-extra
+
+(If you have a HiPS-related webpage or tool or resource you'd like mentioned here, let us know!)
+
+
+Thanks
+======
+
+This package is being developed as part of Google Summer of Code 2017 program
+by Adeel Ahmad, with Thomas Boch (CDS, Strasbourg) and Christoph Deil (MPIK, Heidelberg) as mentors.
+We would like to thank Google, CDS, MPIK for their support!
+
+If you're interested, you should follow Adeel's blog: https://adl1995.github.io/
+
+Also: thanks to the Astropy team for developing and maintaining the
+affiliated package-template and the ci-helpers! The recently introduced cookie-cutter
+makes it even quicker to set up a new package like this one in a good, maintainable way.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,6 +3,3 @@ Reference/API
 
 .. automodapi:: hips
     :no-inheritance-diagram:
-
-.. automodapi:: hips.utils
-    :no-inheritance-diagram:

--- a/docs/develop.rst
+++ b/docs/develop.rst
@@ -6,12 +6,8 @@
 Develop
 *******
 
-To run tests accessing files from `hips-extra <https://github.com/hipspy/hips-extra>`_
-repository, users must have it cloned on their system, otherwise some test cases
-will be skipped. This contains tiles from different HiPS surveys which are used
-by the drawing module. After this, the ``HIPS_EXTRA`` environment variable must
-be set up on their system. On UNIX operating systems, this can be set using
-``export HIPS_EXTRA=path/to/hips-extra``.
+Hello!
+======
 
 Want to contribute to the ``hips`` package?
 
@@ -24,3 +20,71 @@ and everything works pretty much as in Astropy and most affiliated packages.
 We didn't write any developer docs specifically for this package yet.
 For now, check out the Astropy core package developer docs,
 or just talk to us if you have any questions.
+
+Install development version
+===========================
+
+Install the latest development version from https://github.com/hipspy/hips :
+
+.. code-block:: bash
+
+    git clone https://github.com/hipspy/hips
+    cd hips
+    pip install .
+
+Then run the tests with either of these commands:
+
+.. code-block:: bash
+
+    python -m pytest -v hips
+    python setup.py test -V
+
+To run all tests and get a coverage report:
+
+.. code-block:: bash
+
+    python setup.py test -V --remote-data --coverage
+
+To build the documentation, do:
+
+.. code-block:: bash
+
+    python setup.py build_docs
+
+Get the hips-extra test datasets
+================================
+
+To run tests accessing files from `hips-extra <https://github.com/hipspy/hips-extra>`_
+repository, users must have it cloned on their system, otherwise some test cases
+will be skipped. This contains tiles from different HiPS surveys which are used
+by the drawing module. After this, the ``HIPS_EXTRA`` environment variable must
+be set up on their system. On UNIX operating systems, this can be set using
+
+.. code-block:: bash
+
+    export HIPS_EXTRA=path/to/hips-extra
+
+.. _py3:
+
+Why only Python 3?
+==================
+
+This package requires Python 3.6 or later.
+
+It will not work with Python 2.7 or 3.5!
+
+This was a choice we made when starting this package in summer of 2017, at a time
+when Jupyter had just made their Python 3 only release and other packages we depend
+on (like Astropy) were about to drop support for legacy Python (Python 2).
+
+Supporting only Python 3 means we e.g. get these benefits:
+
+* async / await for asynchronous HiPS tile fetching (introduced in Python 3.5)
+* Keyword-only arguments (introduced in Python 3.0)
+* Type annotations (some only introduced in Python 3.6)
+* f-strings (introduced in Python 3.6)
+
+At the moment, the only Python 3.6 only feature we use are f-strings, so if several
+potential users that are on Python 3.5 and can't easily upgrade for some reason
+complain, we might consider supporting Python 3.5 in the next release.
+

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -58,22 +58,36 @@ If you execute the example above, you will get this sky image which was plotted 
 
 .. plot:: plot_fits.py
 
+
+Make a color sky image
+======================
+
+HiPS supports color images in ``jpg`` and ``png`` format.
+Making a color sky image works the same as the grayscale image example above,
+except that you get back a 3-dim Numpy array with ``(R, G, B)`` channels for ``jpg``
+or ``(R, G, B, A)`` channels (``A`` is transparency) for ``png``.
+
+Here's an example using ``jpg`` and http://alasky.u-strasbg.fr/Fermi/Color/ :
+
+.. plot:: plot_jpg.py
+
+
 HiPS data
 =========
 
-TODO: write me
-
-* Explain about tiles
-* File formats
-* Where the HiPS package stores data (in memory and on disk)
-
+We plan to implement functionality to manage HiPS data, i.e. download it and cache it on a local disk.
+This isn't available yet, at the moment we simply use Python lists of `~hips.HipsTile` objects,
+which have a ``read`` method for a given filename and a ``fetch`` method for a given URL.
 
 More advanced examples
 ======================
 
-TODO: write me
+This package is under heavy development, it's changing quickly.
 
-* Show examples for the more low-level, but more configurable classes.
+We'll add ddvance examples and detailed documentation once things have stabilised a bit.
+
+For now, if you know Python, you can look at the code and tests to see what's available:
+https://github.com/hipspy/hips
 
 What next?
 ==========

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -11,7 +11,7 @@ Getting started
 This is a quick getting started guide for the Python `hips` package.
 
 Make a sky image
-----------------
+================
 
 To make a sky image with the `hips` package, follow the following three steps:
 
@@ -59,7 +59,7 @@ If you execute the example above, you will get this sky image which was plotted 
 .. plot:: plot_fits.py
 
 HiPS data
----------
+=========
 
 TODO: write me
 
@@ -69,14 +69,14 @@ TODO: write me
 
 
 More advanced examples
-----------------------
+======================
 
 TODO: write me
 
 * Show examples for the more low-level, but more configurable classes.
 
 What next?
-----------
+==========
 
 That's it, now you've seen the main features of the `hips` package.
 Note that there is API documentation explaining all available functions, classes and parameters.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,40 +1,18 @@
 .. include:: references.txt
 
-#################################
-Python HiPS package documentation
-#################################
+###################
+Python HiPS package
+###################
 
-.. note::
- 
-    This package is being developed as part of Google Summer of Code 2017 program. The progress 
-    of this package will be updated on this `blog <https://adl1995.github.io>`_ and the student's
-    application can be found `here <https://github.com/adl1995/HIPS-to-Py/blob/master/documents/application.md>`_.
-    This ``hips`` package is in a very early stage of development.
-    We started to work on it in June 2017 and expect to have a first v0.1 release in summer 2017.
-    That said, please have a look and try to use it for your applications.
-    Feedback and contributions welcome!
+This is the documentation page for ``hips``.
+A Python astronomy package for HiPS : Hierarchical Progressive Surveys.
 
-This is the documentation for hips.
-
-A Python astronomy package for HiPS : Hierarchical Progressive Surveys
-
-At the moment a client for HiPS images, but other contributions
-(HiPS catalogs or HiPS image generation) welcome!
-
-* Code : https://github.com/hipspy/hips
-* Docs : https://hips.readthedocs.io/
-* Contributors : https://github.com/hipspy/hips/graphs/contributors
-* Releases: https://pypi.python.org/pypi/hips (no releases yet)
-
-More:
-
-* HiPS page at CDS: http://aladin.u-strasbg.fr/hips/ (contains links to HiPS paper and available data)
-* Small example HiPS datasets we use for testing and docs examples: https://github.com/hipspy/hips-extra
 
 .. toctree::
    :maxdepth: 1
    :caption: User documentation
 
+   about
    installation
    getting_started
    api

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,14 +6,65 @@
 Installation
 ************
 
-.. warning::
+Installing the latest stable version is possible either using pip or conda.
 
-    This ``hips`` package is in a very early stage of development.
-    We started to work on it in June 2017 and expect to have a first v0.1 release in summer 2017.
+How to install the latest development version is desribed on the :ref:`develop` page.
 
-    The instructions below will only become accurate once we make a first release.
-    For now, please use the development version!
+Using pip
+=========
 
+To install hips with `pip <http://www.pip-installer.org/en/latest/>`_
+from `PyPI <https://pypi.python.org/pypi/hips>`_, run::
+
+    pip install hips --no-deps
+
+.. note::
+
+    The ``--no-deps`` flag is optional, but highly recommended if you already
+    have Numpy installed, since otherwise pip will sometimes try to "help" you
+    by upgrading your Numpy installation, which may not always be desired.
+
+Using conda
+===========
+
+To install hips with `Anaconda <https://www.continuum.io/downloads>`_
+from the `conda-forge channel on anaconda.org <https://anaconda.org/conda-forge/hips>`__
+simply run::
+
+    conda install -c conda-forge hips
+
+Check installation
+==================
+
+To check if you have ``hips`` installed, where it was installed and which version you have:
+
+.. code-block:: bash
+
+    $ python
+    >>> import hips
+    >>> hips.__version__
+    # -> prints which version you have
+    >>> hips
+    # -> prints where hips is installed
+
+To see if you have the latest stable, released version of ``hips``, you can find that version here:
+
+* https://pypi.python.org/pypi/hips
+* https://anaconda.org/conda-forge/hips
+
+Next you could try running the examples at :ref:`gs` and see if you get the expected output.
+
+It's usually not necessary, but if you find that your ``hips`` installation gives errors
+or unexpected results for examples that should work, you can run the ``hips`` automated tests via:
+
+.. code-block:: bash
+
+    python -c 'import hips; hips.test()'
+
+For more information on automated tests, see the :ref:`develop` page.
+
+Dependencies
+============
 
 The ``hips`` package has the following requirements:
 
@@ -29,82 +80,4 @@ In addition, the following packages are needed for optional functionality:
 
 * `Matplotlib`_ 2.0 or later. Used for plotting in examples.
 
-.. note::
-
-    This package requires Python 3.6 or later. It will not work with Python 2.7 or 3.5!
-
-    Feature or pull requests asking to support older Python versions will be closed.
-    We discussed this point and made an intentional decision to use modern Python features to implement this package.
-
-    E.g. we use the following Python features (very incomplete list):
-
-    * async / await for asynchronous HiPS tile fetching (introduced in Python 3.5)
-    * Keyword-only arguments (introduced in Python 3.0)
-    * f-strings (introduced in Python 3.6)
-    * Type annotations (some only introduced in Python 3.6)
-
-Stable version
-==============
-
-Installing the latest stable version is possible either using pip or conda.
-
-Using pip
----------
-
-To install hips with `pip <http://www.pip-installer.org/en/latest/>`_
-from `PyPI <https://pypi.python.org/pypi/hips>`_, run::
-
-    pip install hips --no-deps
-
-.. note::
-
-    The ``--no-deps`` flag is optional, but highly recommended if you already
-    have Numpy installed, since otherwise pip will sometimes try to "help" you
-    by upgrading your Numpy installation, which may not always be desired.
-
-Using conda
------------
-
-To install hips with `Anaconda <https://www.continuum.io/downloads>`_
-from the `astropy channel on anaconda.org <https://anaconda.org/astropy/hips>`__
-simply run::
-
-    conda install -c astropy hips
-
-Testing installation
---------------------
-
-To check if there are any issues with your installation, you can run the tests:
-
-.. code-block:: bash
-
-    python -c 'import hips; hips.test()'
-
-.. note::
-
-    For more information, see the :ref:`develop` page.
-
-Development version
-===================
-
-Install the latest development version from https://github.com/hipspy/hips :
-
-.. code-block:: bash
-
-    git clone https://github.com/hipspy/hips
-    cd hips
-    pip install .
-
-Then run the tests with either of these commands:
-
-.. code-block:: bash
-
-    python -m pytest hips
-    python setup.py test
-
-
-To build the documentation, do:
-
-.. code-block:: bash
-
-    python setup.py build_docs
+We have some info at :ref:`py3` on why we don't support legacy Python (Python 2).

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -41,10 +41,10 @@ To check if you have ``hips`` installed, where it was installed and which versio
 .. code-block:: bash
 
     $ python
-    >>> import hips
-    >>> hips.__version__
+    >>> import hips  # doctest: +SKIP
+    >>> hips.__version__  # doctest: +SKIP
     # -> prints which version you have
-    >>> hips
+    >>> hips  # doctest: +SKIP
     # -> prints where hips is installed
 
 To see if you have the latest stable, released version of ``hips``, you can find that version here:

--- a/docs/plot_jpg.py
+++ b/docs/plot_jpg.py
@@ -5,18 +5,16 @@ from hips import make_sky_image
 from hips.utils import WCSGeometry
 
 # Compute the sky image
-url = 'http://alasky.unistra.fr/DSS/DSS2Merged/properties'
+url = 'http://alasky.u-strasbg.fr/Fermi/Color/properties'
 hips_survey = HipsSurveyProperties.fetch(url)
 geometry = WCSGeometry.create_simple(
     skydir=SkyCoord(0, 0, unit='deg', frame='galactic'),
     width=2000, height=1000, fov="3 deg",
     coordsys='galactic', projection='AIT',
 )
-image = make_sky_image(geometry=geometry, hips_survey=hips_survey, tile_format='fits')
+image = make_sky_image(geometry=geometry, hips_survey=hips_survey, tile_format='jpg')
 
 # Draw the sky image
 import matplotlib.pyplot as plt
-from astropy.visualization.mpl_normalize import simple_norm
 ax = plt.subplot(projection=geometry.wcs)
-norm = simple_norm(image, 'sqrt')
-ax.imshow(image, origin='lower', norm=norm, cmap='gray')
+ax.imshow(image, origin='lower')

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -3,3 +3,5 @@
 .. _Healpy: https://healpy.readthedocs.io
 .. _scikit-image: http://scikit-image.org
 .. _Pillow: https://python-pillow.org/
+.. _HiPS paper: https://www.aanda.org/articles/aa/pdf/2015/06/aa26075-15.pdf
+.. _HiPS at CDS: http://aladin.u-strasbg.fr/hips/

--- a/hips/__init__.py
+++ b/hips/__init__.py
@@ -20,3 +20,4 @@ if not _ASTROPY_SETUP_:
     # For egg_info test builds to pass, put package imports here.
     from .draw import *
     from .tiles import *
+    from .utils.wcs import WCSGeometry

--- a/hips/draw/tests/test_simple.py
+++ b/hips/draw/tests/test_simple.py
@@ -10,12 +10,30 @@ from ...utils.wcs import WCSGeometry
 from ...utils.testing import make_test_wcs_geometry, requires_hips_extra
 
 make_sky_image_pars = [
-    dict(file_format='fits', shape=(1000, 2000), url='http://alasky.unistra.fr/DSS/DSS2Merged/properties',
-         data_1=2213.30874796, data_2=2296.93885940, data_sum=8757489268.044867),
-    dict(file_format='jpg', shape=(1000, 2000, 3), url='https://raw.githubusercontent.com/hipspy/hips-extra/master/datasets/samples/FermiColor/properties',
-         data_1=[145.388459, 98.579295, 49.792577], data_2=[146.197811, 99.531895, 56.889927], data_sum=813159920.0305891),
-    dict(file_format='png', shape=(1000, 2000, 4), url='https://raw.githubusercontent.com/hipspy/hips-extra/master/datasets/samples/AKARI-FIS/properties',
-         data_1=[249.064796, 237.805612, 190.408181, 255.], data_2=[249.013527, 238.79403, 195.793398, 255.], data_sum=1645783166.1630714)
+    dict(
+        file_format='fits',
+        shape=(1000, 2000),
+        url='http://alasky.unistra.fr/DSS/DSS2Merged/properties',
+        data_1=2213.30874796,
+        data_2=2296.93885940,
+        data_sum=8757489268.044867,
+    ),
+    dict(
+        file_format='jpg',
+        shape=(1000, 2000, 3),
+        url='https://raw.githubusercontent.com/hipspy/hips-extra/master/datasets/samples/FermiColor/properties',
+        data_1=[145.388459, 98.579295, 49.792577],
+        data_2=[146.197811, 99.531895, 56.889927],
+        data_sum=813159920.0305891,
+    ),
+    dict(
+        file_format='png',
+        shape=(1000, 2000, 4),
+        url='https://raw.githubusercontent.com/hipspy/hips-extra/master/datasets/samples/AKARI-FIS/properties',
+        data_1=[249.064796, 237.805612, 190.408181, 255.],
+        data_2=[249.013527, 238.79403, 195.793398, 255.],
+        data_sum=1645783166.1630714
+    ),
 ]
 
 

--- a/hips/tiles/tests/test_surveys.py
+++ b/hips/tiles/tests/test_surveys.py
@@ -2,8 +2,8 @@
 from numpy.testing import assert_allclose
 from astropy.utils.data import get_pkg_data_filename
 from astropy.tests.helper import remote_data
-from ..surveys import HipsSurveyProperties, HipsSurveyPropertiesList
 from ...utils.testing import get_hips_extra_file, requires_hips_extra
+from ..surveys import HipsSurveyProperties, HipsSurveyPropertiesList
 
 
 class TestHipsSurveyProperties:
@@ -34,21 +34,23 @@ class TestHipsSurveyProperties:
         assert self.hips_survey_property.base_url == 'http://alasky.u-strasbg.fr/DSS/DSSColor'
 
     def test_tile_access_url(self):
-        assert self.hips_survey_property.tile_access_url(order=9, ipix=54321) == 'http://alasky.u-strasbg.fr/DSS/DSSColor/Norder9/Dir50000/'
+        actual = self.hips_survey_property.tile_access_url(order=9, ipix=54321)
+        expected = 'http://alasky.u-strasbg.fr/DSS/DSSColor/Norder9/Dir50000/'
+        assert actual == expected
 
-
-@remote_data
-def test_base_url():
-    url = 'http://alasky.u-strasbg.fr/DSS/DSS2-NIR/properties'
-    survey = HipsSurveyProperties.fetch(url)
-
-    assert survey.base_url == 'http://alasky.u-strasbg.fr/DSS/DSS2-NIR'
-
+    @staticmethod
     @requires_hips_extra()
-    def test_tile_width(self):
+    def test_tile_width():
         filename = get_hips_extra_file('datasets/samples/Planck-HFI143/properties')
         survey = HipsSurveyProperties.read(filename)
         assert survey.tile_width == 256
+
+    @staticmethod
+    @remote_data
+    def test_fetch():
+        url = 'http://alasky.u-strasbg.fr/DSS/DSS2-NIR/properties'
+        survey = HipsSurveyProperties.fetch(url)
+        assert survey.base_url == 'http://alasky.u-strasbg.fr/DSS/DSS2-NIR'
 
 
 class TestHipsSurveyPropertiesList:

--- a/hips/tiles/tests/test_tile.py
+++ b/hips/tiles/tests/test_tile.py
@@ -1,70 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 from astropy.tests.helper import remote_data
-from numpy.testing import assert_allclose
-from numpy.testing import assert_equal
-from ..tile import HipsTile, HipsTileMeta
+from numpy.testing import assert_allclose, assert_equal
 from ...utils.testing import get_hips_extra_file, requires_hips_extra
-
-
-class TestHipsTile:
-    fetch_read_pars = [
-        dict(url='http://alasky.unistra.fr/DSS/DSS2Merged/Norder3/Dir0/Npix463.fits',
-             full_path='datasets/samples/DSS2Red/Norder3/Dir0/Npix463.fits',
-             file_name='Npix463.fits', file_format='fits', order=3, ipix=463),
-        dict(url='http://alasky.unistra.fr/DSS/DSS2Merged/Norder3/Dir0/Npix463.jpg',
-             full_path='datasets/samples/DSS2Red/Norder3/Dir0/Npix463.jpg',
-             file_name='Npix463.jpg', file_format='jpg', order=3, ipix=463),
-        dict(url='http://alasky.unistra.fr/2MASS6X/2MASS6X_H/Norder6/Dir0/Npix6112.png',
-             full_path='datasets/samples/2MASS6XH/Norder6/Dir0/Npix6112.png',
-             file_name='Npix6112.png', file_format='png', order=6, ipix=6112)
-    ]
-
-    @remote_data
-    @requires_hips_extra()
-    @pytest.mark.parametrize('pars', fetch_read_pars)
-    def test_fetch_read(self, pars):
-        meta = HipsTileMeta(order=pars['order'], ipix=pars['ipix'], file_format=pars['file_format'])
-        tile_fetched = HipsTile.fetch(meta, url=pars['url'])
-
-        full_path = get_hips_extra_file(pars['full_path'])
-        tile_local = HipsTile.read(meta, full_path=full_path)
-
-        assert tile_fetched == tile_local
-
-    read_write_pars = [
-        dict(full_path='datasets/samples/DSS2Red/Norder3/Dir0/Npix463.fits', file_name='Npix463.fits',
-             file_format='fits', order=3, ipix=463, shape=(512, 512), tile_data=[3047], index=[[510], [5]]),
-        dict(full_path='datasets/samples/DSS2Red/Norder3/Dir0/Npix463.jpg', file_name='Npix463.jpg',
-             file_format='jpg', order=3, ipix=463, shape=(512, 512, 3), tile_data=[[10, 10, 10]], index=[[510], [5]]),
-        dict(full_path='datasets/samples/2MASS6XH/Norder6/Dir0/Npix6112.png', file_name='Npix6112.png',
-             file_format='png', order=6, ipix=6112, shape=(512, 512, 4), tile_data=[[19, 19, 19, 255]], index=[[253], [5]]),
-    ]
-
-    @requires_hips_extra()
-    @pytest.mark.parametrize('pars', read_write_pars)
-    def test_read_write(self, tmpdir, pars):
-        meta = HipsTileMeta(order=pars['order'], ipix=pars['ipix'], file_format=pars['file_format'])
-        full_path = get_hips_extra_file(pars['full_path'])
-        tile = HipsTile.read(meta, full_path)
-
-        assert tile.data.shape == pars['shape']
-        assert_equal(tile.data[pars['index']], pars['tile_data'])
-
-        filename = str(tmpdir / pars['file_name'])
-        tile.write(filename)
-        tile2 = HipsTile.read(meta, full_path=filename)
-
-        # TODO: Fix JPG write issue
-        # assert tile == tile2
-
-    @requires_hips_extra()
-    def test_value_error(self):
-        # `file_format` of "jpeg" is invalid. Should be "jpg"
-        meta = HipsTileMeta(order=3, ipix=463, file_format='jpeg')
-        full_path = get_hips_extra_file('datasets/samples/DSS2Red/Norder3/Dir0/Npix463.jpg')
-        with pytest.raises(ValueError):
-            HipsTile.read(meta, full_path)
+from ..tile import HipsTileMeta, HipsTile
 
 
 class TestHipsTileMeta:
@@ -89,7 +28,85 @@ class TestHipsTileMeta:
         assert_allclose(self.meta.skycoord_corners.data.lon.deg, [264.375, 258.75, 264.375, 270.])
         assert self.meta.skycoord_corners.frame.name == 'icrs'
 
+    @staticmethod
+    def test_skycoord_corners_galactic():
         meta = HipsTileMeta(order=3, ipix=450, file_format='fits', frame='galactic')
         assert_allclose(meta.skycoord_corners.data.lat.deg, [-24.624318, -30., -35.685335, -30.])
         assert_allclose(meta.skycoord_corners.data.lon.deg, [264.375, 258.75, 264.375, 270.])
         assert meta.skycoord_corners.frame.name == 'galactic'
+
+
+HIPS_TILE_TEST_CASES = [
+    dict(
+        meta=dict(order=3, ipix=463, file_format='fits'),
+        url='http://alasky.unistra.fr/DSS/DSS2Merged/Norder3/Dir0/Npix463.fits',
+        full_path='datasets/samples/DSS2Red/Norder3/Dir0/Npix463.fits',
+        file_name='Npix463.fits',
+
+        shape=(512, 512),
+        pix_idx=[[510], [5]],
+        pix_val=[3047],
+    ),
+    dict(
+        meta=dict(order=3, ipix=463, file_format='jpg'),
+        url='http://alasky.unistra.fr/DSS/DSS2Merged/Norder3/Dir0/Npix463.jpg',
+        full_path='datasets/samples/DSS2Red/Norder3/Dir0/Npix463.jpg',
+        file_name='Npix463.jpg',
+
+        shape=(512, 512, 3),
+        pix_idx=[[510], [5]],
+        pix_val=[[10, 10, 10]],
+    ),
+    dict(
+        meta=dict(order=6, ipix=6112, file_format='png'),
+        url='http://alasky.unistra.fr/2MASS6X/2MASS6X_H/Norder6/Dir0/Npix6112.png',
+        full_path='datasets/samples/2MASS6XH/Norder6/Dir0/Npix6112.png',
+        file_name='Npix6112.png',
+
+        shape=(512, 512, 4),
+        pix_idx=[[253], [5]],
+        pix_val=[[19, 19, 19, 255]],
+    ),
+]
+
+
+class TestHipsTile:
+    @requires_hips_extra()
+    @pytest.mark.parametrize('pars', HIPS_TILE_TEST_CASES)
+    def test_read_write(self, tmpdir, pars):
+        # Check that reading tiles in various formats works,
+        # and that read / write round-trips, i.e. works properly
+        meta = HipsTileMeta(**pars['meta'])
+        full_path = get_hips_extra_file(pars['full_path'])
+        tile = HipsTile.read(meta, full_path)
+
+        assert tile.data.shape == pars['shape']
+        assert_equal(tile.data[pars['pix_idx']], pars['pix_val'])
+
+        filename = str(tmpdir / pars['file_name'])
+        tile.write(filename)
+        tile2 = HipsTile.read(meta, full_path=filename)
+
+        # TODO: Fix JPG write issue
+        # assert tile == tile2
+
+    @requires_hips_extra()
+    def test_value_error(self):
+        # Check that an invalid `file_format` string like "jpeg" (should be "jpg") gives a ValueError
+        meta = HipsTileMeta(order=3, ipix=463, file_format='jpeg')
+        full_path = get_hips_extra_file('datasets/samples/DSS2Red/Norder3/Dir0/Npix463.jpg')
+        with pytest.raises(ValueError):
+            HipsTile.read(meta, full_path)
+
+    @remote_data
+    @requires_hips_extra()
+    @pytest.mark.parametrize('pars', HIPS_TILE_TEST_CASES)
+    def test_fetch(self, pars):
+        # Check that tile HTTP fetch gives the same result as tile read from disk
+        meta = HipsTileMeta(**pars['meta'])
+        tile_fetched = HipsTile.fetch(meta, url=pars['url'])
+
+        full_path = get_hips_extra_file(pars['full_path'])
+        tile_local = HipsTile.read(meta, full_path=full_path)
+
+        assert tile_fetched == tile_local

--- a/hips/tiles/tile.py
+++ b/hips/tiles/tile.py
@@ -14,8 +14,8 @@ from astropy.io.fits.header import Header
 from ..utils import boundaries
 
 __all__ = [
+    'HipsTileMeta',
     'HipsTile',
-    'HipsTileMeta'
 ]
 
 __doctest_skip__ = ['HipsTile']

--- a/hips/utils/healpix.py
+++ b/hips/utils/healpix.py
@@ -27,11 +27,6 @@ def _skycoord_to_theta_phi(skycoord: SkyCoord) -> Tuple[float, float]:
     return theta, phi
 
 
-def _skycoord_to_vec(skycoord: SkyCoord) -> np.ndarray:
-    """Convert SkyCoord to vec as used in healpy."""
-    return hp.ang2vec(*_skycoord_to_theta_phi(skycoord))
-
-
 def boundaries(nside: int, pix: int, nest: bool = True) -> tuple:
     """Returns an array containing the angle (theta and phi) in radians.
 

--- a/hips/utils/healpix.py
+++ b/hips/utils/healpix.py
@@ -4,11 +4,10 @@
 This module contains wrapper functions around HEALPix utilizing
 the healpy library.
 """
+from typing import Tuple
 import healpy as hp
 import numpy as np
 from astropy.coordinates import SkyCoord
-from typing import Tuple
-
 from .wcs import WCSGeometry
 
 __all__ = [
@@ -17,7 +16,10 @@ __all__ = [
     'get_hips_order_for_resolution'
 ]
 
-__doctest_skip__ = ['boundaries', 'compute_healpix_pixel_indices']
+__doctest_skip__ = [
+    'boundaries',
+    'compute_healpix_pixel_indices',
+]
 
 
 def _skycoord_to_theta_phi(skycoord: SkyCoord) -> Tuple[float, float]:
@@ -107,14 +109,14 @@ def compute_healpix_pixel_indices(wcs_geometry: WCSGeometry, order: int, healpix
     return np.unique(ipix)
 
 
-def get_hips_order_for_resolution(tile_width: int, resolution: int) -> int:
+def get_hips_order_for_resolution(tile_width: int, resolution: float) -> int:
     """Find the best HiPS order by looping through all possible options.
 
     Parameters
     ----------
     tile_width : int
         HiPS tile width
-    resolution : int
+    resolution : float
         Sky image angular resolution (pixel size in degrees)
 
     Returns

--- a/hips/utils/tests/test_healpix.py
+++ b/hips/utils/tests/test_healpix.py
@@ -22,26 +22,21 @@ def test_boundaries():
     assert_allclose(radec.dec.deg, [-24.624318, -30., -35.685335, -30.])
 
 
-compute_healpix_pixel_indices_pars = [
+@pytest.mark.parametrize('pars', [
     dict(frame='galactic', ipix=[269, 270, 271, 280, 282, 283, 292, 293, 295, 304, 305, 306]),
     dict(frame='icrs', ipix=[448, 449, 450, 451, 454, 456, 457, 460, 661, 663, 669]),
-]
-
-
-@pytest.mark.parametrize('pars', compute_healpix_pixel_indices_pars)
+])
 def test_wcs_healpix_pixel_indices(pars):
     geometry = make_test_wcs_geometry(case=2)
     healpix_pixel_indices = compute_healpix_pixel_indices(geometry, order=3, healpix_frame=pars['frame'])
     assert list(healpix_pixel_indices) == pars['ipix']
 
-hips_order_for_resolution_pars = [
+
+@pytest.mark.parametrize('pars', [
     dict(tile_width=512, resolution=0.01232, resolution_res=0.06395791924665553, order=4),
     dict(tile_width=256, resolution=0.0016022, resolution_res=0.003997369952915971, order=8),
     dict(tile_width=128, resolution=0.00009032, resolution_res=0.00012491781102862408, order=13),
-]
-
-
-@pytest.mark.parametrize('pars', hips_order_for_resolution_pars)
+])
 def test_get_hips_order_for_resolution(pars):
     hips_order = get_hips_order_for_resolution(pars['tile_width'], pars['resolution'])
     assert hips_order == pars['order']

--- a/hips/utils/tests/test_wcs.py
+++ b/hips/utils/tests/test_wcs.py
@@ -8,8 +8,8 @@ class TestWCSGeometry:
     def setup(self):
         self.wcs_geometry = WCSGeometry.create_simple(
             skydir=SkyCoord(0, 0, unit='deg', frame='galactic'),
-            width=2000, height=1000, fov="3 deg",
-            coordsys='galactic', projection='AIT'
+            width=2000, height=1000, fov='3 deg',
+            coordsys='galactic', projection='AIT',
         )
 
     def test_galactic_frame_center(self):
@@ -24,7 +24,7 @@ class TestWCSGeometry:
     def test_celestial_frame(self):
         wcs_geometry = WCSGeometry.create_simple(
             skydir=SkyCoord(0, 0, unit='deg', frame='icrs'),
-            width=2000, height=1000, fov="3 deg",
+            width=2000, height=1000, fov='3 deg',
             coordsys='icrs', projection='AIT'
         )
         c = wcs_geometry.center_skycoord

--- a/hips/utils/wcs.py
+++ b/hips/utils/wcs.py
@@ -26,10 +26,8 @@ class WCSGeometry:
     ----------
     wcs : `~astropy.wcs.WCS`
         WCS projection object
-    width : int
-        Width of the image in pixels
-    height : int
-        Height of the image in pixels
+    width, height : int
+        Width and height of the image in pixels
 
     Examples
     --------
@@ -91,13 +89,11 @@ class WCSGeometry:
         ----------
         skydir : `~astropy.coordinates.SkyCoord`
             Sky coordinate of the WCS reference point
-        width : `int`
-            Width of the image in pixels
-        height : `int`
-            Height of the image in pixels
+        width, height : int
+            Width and height of the image in pixels
         coordsys : {'icrs', 'galactic'}
             Coordinate system
-        projection : `str`
+        projection : str
             Projection of the WCS object.
             To see list of supported projections
             visit: http://docs.astropy.org/en/stable/wcs/#supported-projections
@@ -141,10 +137,8 @@ class WCSGeometry:
         ----------
         skydir : `~astropy.coordinates.SkyCoord`
             Sky coordinate of the WCS reference point
-        width : `int`
-            Width of the image in pixels
-        height : `int`
-            Height of the image in pixels
+        width, height : int
+            Width and height of the image in pixels
         fov: `str` or Angle
             Field of view
         coordsys : {'icrs', 'galactic'}

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ show-response = 1
 minversion = 3.0
 norecursedirs = build docs/_build
 doctest_plus = enabled
-doctest_norecursedirs = docs/plot_fits.py
+doctest_norecursedirs = docs/*.py
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
This pull request contains some misc changes and cleanup I'd like to make before releasing v0.1:

- [x] Don't expose `hips.utils` in the public docs. Make it simple for end-users and expose everything they should know about in the top-level `hips` namespace. The one thing from `hips.utils` that they need is `WCSGeometry`, which I import into the top-level `hips` namespace.
- [x] Shorten the docs landing page, move the content to a new "about" page.
- [x] Update drawing description to what we do in the code (e.g. projective transform, not affine transform with triangles)
- [x] Update getting started guide to include a color image draw example.
- [x] Misc code, test and docstring cleanup

@tboch - Do you want to review this today or are you already on vacation?