### PR TITLE
Improve tile I/O

### DIFF
--- a/hips/draw/simple.py
+++ b/hips/draw/simple.py
@@ -111,7 +111,7 @@ class SimpleTilePainter:
                 frame=self.hips_survey.astropy_frame,
                 file_format=self.tile_format,
             )
-            url = self.hips_survey.tile_access_url(order=self.draw_hips_order, ipix=healpix_pixel_index) + tile_meta.filename
+            url = self.hips_survey.tile_url(tile_meta)
             tile = HipsTile.fetch(tile_meta, url)
             yield tile
 

--- a/hips/tiles/io.py
+++ b/hips/tiles/io.py
@@ -1,0 +1,28 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Tile input / output (I/O) methods (both local and remote)."""
+from typing import List
+from pathlib import Path
+
+__all__ = [
+]
+
+
+def _tile_default_location(order: int, ipix: int, file_format: str) -> List[str]:
+    # Directory index: HiPS tiles are grouped in chunks of 10k tiles
+    dir_idx = (ipix // 10_000) * 10_000
+
+    return [
+        f'Norder{order}',
+        f'Dir{dir_idx}',
+        f'Npix{ipix}.{file_format}',
+    ]
+
+
+def tile_default_url(order: int, ipix: int, file_format: str) -> str:
+    loc = _tile_default_location(order, ipix, file_format)
+    return '/'.join(loc)
+
+
+def tile_default_path(order: int, ipix: int, file_format: str) -> Path:
+    loc = _tile_default_location(order, ipix, file_format)
+    return Path(*loc)

--- a/hips/tiles/surveys.py
+++ b/hips/tiles/surveys.py
@@ -5,6 +5,7 @@ from csv import DictWriter
 import urllib.request
 from typing import List
 from astropy.table import Table
+from .tile import HipsTileMeta
 
 __all__ = [
     'HipsSurveyProperties',
@@ -101,37 +102,47 @@ class HipsSurveyProperties:
 
     @property
     def title(self) -> str:
-        """HiPS title (`str`)."""
+        """HiPS title (str)."""
         return self.data['obs_title']
 
     @property
     def hips_version(self) -> str:
-        """HiPS version (`str`)."""
+        """HiPS version (str)."""
         return self.data['hips_version']
 
     @property
     def hips_frame(self) -> str:
-        """HiPS coordinate frame (`str`)."""
+        """HiPS coordinate frame (str)."""
         return self.data['hips_frame']
 
     @property
     def astropy_frame(self) -> str:
-        """Astropy coordinate frame (`str`)."""
+        """Astropy coordinate frame (str)."""
         return self.hips_to_astropy_frame_mapping[self.hips_frame]
 
     @property
     def hips_order(self) -> int:
-        """HiPS order (`int`)."""
+        """HiPS order (int)."""
         return int(self.data['hips_order'])
 
     @property
+    def tile_width(self) -> int:
+        """HiPS tile width"""
+        return int(self.data['hips_tile_width']) or 512
+
+    @property
     def tile_format(self) -> str:
-        """HiPS tile format (`str`)."""
+        """HiPS tile format (str)."""
         return self.data['hips_tile_format']
 
     @property
+    def hips_service_url(self) -> str:
+        """HiPS service base URL (str)."""
+        return self.data['hips_service_url']
+
+    @property
     def base_url(self) -> str:
-        """HiPS access url"""
+        """HiPS access URL"""
         try:
             return self.data['hips_service_url']
         except KeyError:
@@ -140,48 +151,12 @@ class HipsSurveyProperties:
             except KeyError:
                 try:
                     return self.data['properties_url']
-                except:
-                    return ValueError('URL does not exist!')
+                except KeyError:
+                    raise ValueError('URL does not exist!')
 
-    @property
-    def tile_width(self) -> int:
-        """HiPS tile width"""
-        return int(self.data['hips_tile_width']) or 512
-
-    def directory(self, ipix: int) -> int:
-        """Directory index containing HiPS tile(s)"""
-        return (ipix // 10000) * 10000
-
-    def tile_access_url(self, order: int, ipix: int) -> str:
-        """Tile access URL
-
-        Parameters
-        ----------
-        order : int
-            HiPS order
-        ipix : int
-            Index of the HiPS tile
-        """
-        return self.base_url + '/Norder' + str(order) + '/Dir' + str(self.directory(ipix)) + '/'
-
-    def tile_path(self, order: int, ipix: int, tile_format: str) -> str:
-        """Tile access URL
-
-        Parameters
-        ----------
-        order : int
-            HiPS order
-        ipix : int
-            Index of the HiPS tile
-        tile_format : str
-            HiPS tile URL
-        """
-        return '/Norder' + str(order) + '/Dir' + str(self.directory(ipix)) + '/Npix' + str(ipix) + '.' + tile_format
-
-    @property
-    def hips_service_url(self) -> str:
-        """HiPS service base URL (`str`)."""
-        return self.data['hips_service_url']
+    def tile_url(self, tile_meta: HipsTileMeta) -> str:
+        """Tile URL on the server (str)."""
+        return self.base_url + '/' + tile_meta.tile_default_url
 
 
 class HipsSurveyPropertiesList:

--- a/hips/tiles/tests/test_io.py
+++ b/hips/tiles/tests/test_io.py
@@ -1,0 +1,13 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from pathlib import Path
+from ..io import tile_default_url, tile_default_path
+
+
+def test_tile_default_url():
+    url = tile_default_url(order=9, ipix=54321, file_format='fits')
+    assert url == 'Norder9/Dir50000/Npix54321.fits'
+
+
+def test_tile_default_url():
+    path = tile_default_path(order=9, ipix=54321, file_format='fits')
+    assert path == Path('Norder9/Dir50000/Npix54321.fits')

--- a/hips/tiles/tests/test_surveys.py
+++ b/hips/tiles/tests/test_surveys.py
@@ -3,6 +3,7 @@ from numpy.testing import assert_allclose
 from astropy.utils.data import get_pkg_data_filename
 from astropy.tests.helper import remote_data
 from ...utils.testing import get_hips_extra_file, requires_hips_extra
+from ..tile import HipsTileMeta
 from ..surveys import HipsSurveyProperties, HipsSurveyPropertiesList
 
 
@@ -10,33 +11,34 @@ class TestHipsSurveyProperties:
     @classmethod
     def setup_class(cls):
         filename = get_pkg_data_filename('data/properties.txt')
-        cls.hips_survey_property = HipsSurveyProperties.read(filename)
+        cls.hips_survey = HipsSurveyProperties.read(filename)
 
     def test_title(self):
-        assert self.hips_survey_property.title == 'DSS colored'
+        assert self.hips_survey.title == 'DSS colored'
 
     def test_hips_version(self):
-        assert self.hips_survey_property.hips_version == '1.31'
+        assert self.hips_survey.hips_version == '1.31'
 
     def test_hips_frame(self):
-        assert self.hips_survey_property.hips_frame == 'equatorial'
+        assert self.hips_survey.hips_frame == 'equatorial'
 
     def test_astropy_frame(self):
-        assert self.hips_survey_property.astropy_frame == 'icrs'
+        assert self.hips_survey.astropy_frame == 'icrs'
 
     def test_hips_order(self):
-        assert self.hips_survey_property.hips_order == 9
+        assert self.hips_survey.hips_order == 9
 
     def test_tile_format(self):
-        assert self.hips_survey_property.tile_format == 'jpeg'
+        assert self.hips_survey.tile_format == 'jpeg'
 
     def test_base_url(self):
-        assert self.hips_survey_property.base_url == 'http://alasky.u-strasbg.fr/DSS/DSSColor'
+        expected = 'http://alasky.u-strasbg.fr/DSS/DSSColor'
+        assert self.hips_survey.base_url == expected
 
-    def test_tile_access_url(self):
-        actual = self.hips_survey_property.tile_access_url(order=9, ipix=54321)
-        expected = 'http://alasky.u-strasbg.fr/DSS/DSSColor/Norder9/Dir50000/'
-        assert actual == expected
+    def test_tile_default_url(self):
+        tile_meta = HipsTileMeta(order=9, ipix=54321, file_format='fits')
+        url = self.hips_survey.tile_url(tile_meta)
+        assert url == 'http://alasky.u-strasbg.fr/DSS/DSSColor/Norder9/Dir50000/Npix54321.fits'
 
     @staticmethod
     @requires_hips_extra()

--- a/hips/tiles/tests/test_tile.py
+++ b/hips/tiles/tests/test_tile.py
@@ -75,6 +75,10 @@ class TestHipsTile:
         filename = get_hips_extra_file(pars['filename'])
         return HipsTile.read(meta, filename)
 
+    # TODO: implement tests for the `from_numpy` method!
+    def _test_from_numpy(self):
+        pass
+
     @requires_hips_extra()
     @pytest.mark.parametrize('pars', HIPS_TILE_TEST_CASES)
     def test_read(self, pars):
@@ -91,18 +95,6 @@ class TestHipsTile:
         assert data.dtype.name == pars['dtype']
         assert_equal(tile.data[pars['pix_idx']], pars['pix_val'])
 
-    @requires_hips_extra()
-    @pytest.mark.parametrize('pars', HIPS_TILE_TEST_CASES)
-    def test_write(self, tmpdir, pars):
-        # Check that tile I/O works, i.e. round-trips on write / read
-        tile = self._read_tile(pars)
-
-        filename = tmpdir / Path(pars['filename']).name
-        tile.write(filename)
-        tile2 = HipsTile.read(tile.meta, filename)
-
-        assert tile == tile2
-
     @remote_data
     @requires_hips_extra()
     @pytest.mark.parametrize('pars', HIPS_TILE_TEST_CASES)
@@ -115,3 +107,15 @@ class TestHipsTile:
         tile_read = HipsTile.read(meta, filename)
 
         assert tile_fetch == tile_read
+
+    @requires_hips_extra()
+    @pytest.mark.parametrize('pars', HIPS_TILE_TEST_CASES)
+    def test_write(self, tmpdir, pars):
+        # Check that tile I/O works, i.e. round-trips on write / read
+        tile = self._read_tile(pars)
+
+        filename = tmpdir / Path(pars['filename']).name
+        tile.write(filename)
+        tile2 = HipsTile.read(tile.meta, filename)
+
+        assert tile == tile2

--- a/hips/tiles/tests/test_tile.py
+++ b/hips/tiles/tests/test_tile.py
@@ -11,38 +11,35 @@ class TestHipsTileMeta:
     def setup_class(cls):
         cls.meta = HipsTileMeta(order=3, ipix=450, file_format='fits', frame='icrs')
 
-    def test_path(self):
-        assert str(self.meta.path) == 'hips/tiles/tests/data'
-
-    def test_filename(self):
-        assert self.meta.filename == 'Npix450.fits'
-
-    def test_full_path(self):
-        assert str(self.meta.full_path) == 'hips/tiles/tests/data/Npix450.fits'
-
     def test_nside(self):
         assert self.meta.nside == 8
 
     def test_skycoord_corners(self):
-        assert_allclose(self.meta.skycoord_corners.data.lat.deg, [-24.624318, -30., -35.685335, -30.])
-        assert_allclose(self.meta.skycoord_corners.data.lon.deg, [264.375, 258.75, 264.375, 270.])
+        coord = self.meta.skycoord_corners
+        assert_allclose(coord.data.lat.deg, [-24.624318, -30., -35.685335, -30.])
+        assert_allclose(coord.data.lon.deg, [264.375, 258.75, 264.375, 270.])
         assert self.meta.skycoord_corners.frame.name == 'icrs'
 
     @staticmethod
     def test_skycoord_corners_galactic():
         meta = HipsTileMeta(order=3, ipix=450, file_format='fits', frame='galactic')
-        assert_allclose(meta.skycoord_corners.data.lat.deg, [-24.624318, -30., -35.685335, -30.])
-        assert_allclose(meta.skycoord_corners.data.lon.deg, [264.375, 258.75, 264.375, 270.])
-        assert meta.skycoord_corners.frame.name == 'galactic'
+        coord = meta.skycoord_corners
+        assert_allclose(coord.data.lat.deg, [-24.624318, -30., -35.685335, -30.])
+        assert_allclose(coord.data.lon.deg, [264.375, 258.75, 264.375, 270.])
+        assert coord.frame.name == 'galactic'
+
+    def test_tile_url(self):
+        url = self.meta.tile_default_url
+        assert url == 'Norder3/Dir0/Npix450.fits'
 
 
 HIPS_TILE_TEST_CASES = [
     dict(
         meta=dict(order=3, ipix=463, file_format='fits'),
         url='http://alasky.unistra.fr/DSS/DSS2Merged/Norder3/Dir0/Npix463.fits',
-        full_path='datasets/samples/DSS2Red/Norder3/Dir0/Npix463.fits',
-        file_name='Npix463.fits',
+        filename='datasets/samples/DSS2Red/Norder3/Dir0/Npix463.fits',
 
+        dtype='int16',
         shape=(512, 512),
         pix_idx=[[510], [5]],
         pix_val=[3047],
@@ -50,9 +47,9 @@ HIPS_TILE_TEST_CASES = [
     dict(
         meta=dict(order=3, ipix=463, file_format='jpg'),
         url='http://alasky.unistra.fr/DSS/DSS2Merged/Norder3/Dir0/Npix463.jpg',
-        full_path='datasets/samples/DSS2Red/Norder3/Dir0/Npix463.jpg',
-        file_name='Npix463.jpg',
+        filename='datasets/samples/DSS2Red/Norder3/Dir0/Npix463.jpg',
 
+        dtype='uint8',
         shape=(512, 512, 3),
         pix_idx=[[510], [5]],
         pix_val=[[10, 10, 10]],
@@ -60,9 +57,9 @@ HIPS_TILE_TEST_CASES = [
     dict(
         meta=dict(order=6, ipix=6112, file_format='png'),
         url='http://alasky.unistra.fr/2MASS6X/2MASS6X_H/Norder6/Dir0/Npix6112.png',
-        full_path='datasets/samples/2MASS6XH/Norder6/Dir0/Npix6112.png',
-        file_name='Npix6112.png',
+        filename='datasets/samples/2MASS6XH/Norder6/Dir0/Npix6112.png',
 
+        dtype='uint8',
         shape=(512, 512, 4),
         pix_idx=[[253], [5]],
         pix_val=[[19, 19, 19, 255]],
@@ -73,30 +70,30 @@ HIPS_TILE_TEST_CASES = [
 class TestHipsTile:
     @requires_hips_extra()
     @pytest.mark.parametrize('pars', HIPS_TILE_TEST_CASES)
-    def test_read_write(self, tmpdir, pars):
+    def test_read(self, pars):
         # Check that reading tiles in various formats works,
-        # and that read / write round-trips, i.e. works properly
+        # i.e. that pixel data in numpy array format
+        # has correct shape, dtype and values
         meta = HipsTileMeta(**pars['meta'])
-        full_path = get_hips_extra_file(pars['full_path'])
-        tile = HipsTile.read(meta, full_path)
+        filename = get_hips_extra_file(pars['filename'])
+        tile = HipsTile.read(meta, filename)
+        data = tile.data
 
-        assert tile.data.shape == pars['shape']
+        assert data.shape == pars['shape']
+        assert data.dtype.name == pars['dtype']
         assert_equal(tile.data[pars['pix_idx']], pars['pix_val'])
 
-        filename = str(tmpdir / pars['file_name'])
-        tile.write(filename)
-        tile2 = HipsTile.read(meta, full_path=filename)
+    # @requires_hips_extra()
+    # @pytest.mark.parametrize('pars', HIPS_TILE_TEST_CASES)
+    # def test_write(self, tmpdir, pars):
+    #
+    #         filename = str(tmpdir / pars['file_name'])
+    #     tile.write(filename)
+    #     tile2 = HipsTile.read(meta, full_path=filename)
+    #
+    #     # TODO: Fix JPG write issue
+    #     # assert tile == tile2
 
-        # TODO: Fix JPG write issue
-        # assert tile == tile2
-
-    @requires_hips_extra()
-    def test_value_error(self):
-        # Check that an invalid `file_format` string like "jpeg" (should be "jpg") gives a ValueError
-        meta = HipsTileMeta(order=3, ipix=463, file_format='jpeg')
-        full_path = get_hips_extra_file('datasets/samples/DSS2Red/Norder3/Dir0/Npix463.jpg')
-        with pytest.raises(ValueError):
-            HipsTile.read(meta, full_path)
 
     @remote_data
     @requires_hips_extra()
@@ -104,9 +101,9 @@ class TestHipsTile:
     def test_fetch(self, pars):
         # Check that tile HTTP fetch gives the same result as tile read from disk
         meta = HipsTileMeta(**pars['meta'])
-        tile_fetched = HipsTile.fetch(meta, url=pars['url'])
+        tile_fetch = HipsTile.fetch(meta, url=pars['url'])
 
-        full_path = get_hips_extra_file(pars['full_path'])
-        tile_local = HipsTile.read(meta, full_path=full_path)
+        filename = get_hips_extra_file(pars['filename'])
+        tile_read = HipsTile.read(meta, filename)
 
-        assert tile_fetched == tile_local
+        assert tile_fetch == tile_read

--- a/hips/tiles/tile.py
+++ b/hips/tiles/tile.py
@@ -12,6 +12,7 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.io.fits.header import Header
 from ..utils import boundaries
+from .io import tile_default_url
 
 __all__ = [
     'HipsTileMeta',
@@ -26,9 +27,9 @@ class HipsTileMeta:
 
     Parameters
     ----------
-    order : `int`
+    order : int
         HEALPix order
-    ipix : `int`
+    ipix : int
         HEALPix pixel number
     file_format : {'fits', 'jpg', 'png'}
         File format
@@ -45,7 +46,7 @@ class HipsTileMeta:
     ( 264.375, -35.68533471), ( 270.   , -30.        )]>
     """
 
-    def __init__(self, order: int, ipix: int, file_format: str, frame: str = 'galactic') -> None:
+    def __init__(self, order: int, ipix: int, file_format: str, frame: str = 'icrs') -> None:
         self.order = order
         self.ipix = ipix
         self.file_format = file_format
@@ -59,30 +60,20 @@ class HipsTileMeta:
         )
 
     @property
-    def path(self) -> Path:
-        """Default path for tile storage (`~pathlib.Path`)."""
-        return Path('hips', 'tiles', 'tests', 'data')
-
-    @property
-    def filename(self) -> str:
-        """Filename for HiPS tile (`str`)."""
-        return ''.join(['Npix', str(self.ipix), '.', self.file_format])
-
-    @property
-    def full_path(self) -> Path:
-        """Full path (folder and filename) (`~pathlib.Path`)"""
-        return self.path / self.filename
-
-    @property
     def nside(self) -> int:
-        """nside of the HEALPix map"""
+        """HEALPix nside (int)"""
         return hp.order2nside(self.order)
 
     @property
     def skycoord_corners(self) -> SkyCoord:
-        """Corner values for a HiPS tile"""
+        """Corner sky coordinates (`~astropy.coordinates.SkyCoord`)"""
         theta, phi = boundaries(self.nside, self.ipix)
         return SkyCoord(phi, np.pi / 2 - theta, unit='radian', frame=self.frame)
+
+    @property
+    def tile_default_url(self) -> str:
+        """Tile relative URL in the default scheme."""
+        return tile_default_url(self.order, self.ipix, self.file_format)
 
 
 class HipsTile:
@@ -92,27 +83,29 @@ class HipsTile:
 
     Parameters
     ----------
-    meta : `HipsTileMeta`
+    meta : `~hips.HipsTileMeta`
         Metadata of HiPS tile
     data : `~numpy.ndarray`
         Data containing HiPS tile
-    header : `~astropy.io.fits.Header`
-        Header of HiPS tile
 
     Examples
     --------
+
+    Fetch a HiPS tile:
+
     >>> from hips.tiles import HipsTile, HipsTileMeta
     >>> meta = HipsTileMeta(order=6, ipix=30889, file_format='fits')
     >>> url = 'http://alasky.unistra.fr/2MASS/H/Norder6/Dir30000/Npix30889.fits'
     >>> tile = HipsTile.fetch(meta, url)
-    >>> tile.data
-    array([[0, 0, 0, ..., 0, 0, 0],
-           [0, 0, 0, ..., 0, 0, 0],
-           [0, 0, 0, ..., 0, 0, 0],
-           ...,
-           [0, 0, 0, ..., 1, 0, 0],
-           [0, 0, 0, ..., 1, 0, 1],
-           [0, 0, 0, ..., 1, 0, 1]], dtype=int16)
+
+    The tile pixel data is available as a Numpy array:
+
+    >>> type(tile.data)
+    numpy.ndarray
+    >>> tile.data.shape
+    (512, 512)
+    >>> tile.data.dtype.name
+    int16
     """
 
     def __init__(self, meta: HipsTileMeta, data: np.ndarray = None, header: Header = None) -> None:
@@ -130,13 +123,13 @@ class HipsTile:
 
     @classmethod
     def fetch(cls, meta: HipsTileMeta, url: str) -> 'HipsTile':
-        """Fetch HiPS tile and load into memory (`HipsTile`).
+        """Fetch HiPS tile and load into memory (`~hips.HipsTile`).
 
         Parameters
         ----------
-        meta : `HipsTileMeta`
+        meta : `~hips.HipsTileMeta`
             Metadata of HiPS tile
-        url : `str`
+        url : str
             URL containing HiPS tile
         """
         with urllib.request.urlopen(url) as response:
@@ -145,17 +138,18 @@ class HipsTile:
         return cls._from_raw_data(meta, raw_data)
 
     @classmethod
-    def read(cls, meta: HipsTileMeta, full_path: str = None) -> 'HipsTile':
-        """Read HiPS tile data from a directory and load into memory (`HipsTile`).
+    def read(cls, meta: HipsTileMeta, filename: str = None) -> 'HipsTile':
+        """Read HiPS tile data from a directory and load into memory (`~hips.HipsTile`).
 
         Parameters
         ----------
-        meta : `HipsTileMeta`
+        meta : `~hips.HipsTileMeta`
             Metadata of HiPS tile
-        full_path : `str`
-            File path to store a HiPS tile
+        filename : str
+            Filename
         """
-        path = Path(full_path) or meta.full_path
+        path = Path(filename)
+
         with path.open(mode='rb') as fh:
             raw_data = BytesIO(fh.read())
 
@@ -181,17 +175,17 @@ class HipsTile:
             return cls(meta, data)
         else:
             raise ValueError(f'Tile file format not supported: {meta.file_format}. '
-                              'Supported formats: fits, jpg, png')
+                             'Supported formats: fits, jpg, png')
 
-    def write(self, full_path: str = None) -> None:
-        """Write HiPS tile by a given filename.
+    def write(self, filename: str) -> None:
+        """Write to file.
 
         Parameters
         ----------
-        full_path : `str`
-            Name of the file
+        filename : str
+            Filename
         """
-        path = Path(full_path) or meta.full_path
+        path = Path(filename)
         file_format = self.meta.file_format
 
         if file_format == 'fits':
@@ -205,4 +199,4 @@ class HipsTile:
             image.save(str(path))
         else:
             raise ValueError(f'Tile file format not supported: {file_format}. '
-                              'Supported formats: fits, jpg, png')  # pragma: no cover
+                             'Supported formats: fits, jpg, png')  # pragma: no cover

--- a/hips/utils/wcs.py
+++ b/hips/utils/wcs.py
@@ -97,9 +97,9 @@ class WCSGeometry:
             Projection of the WCS object.
             To see list of supported projections
             visit: http://docs.astropy.org/en/stable/wcs/#supported-projections
-        cdelt : `float`
+        cdelt : float
             Coordinate increment at reference point
-        crpix : `tuple`
+        crpix : tuple
             Pixel coordinates of reference point
             (WCS axis order: x, y and FITS convention origin=1)
         """
@@ -139,11 +139,11 @@ class WCSGeometry:
             Sky coordinate of the WCS reference point
         width, height : int
             Width and height of the image in pixels
-        fov: `str` or Angle
+        fov: str or `~astropy.coordinates.Angle`
             Field of view
         coordsys : {'icrs', 'galactic'}
             Coordinate system
-        projection : `str`
+        projection : str
             Projection of the WCS object.
             To see list of supported projections
             visit: http://docs.astropy.org/en/stable/wcs/#supported-projections
@@ -155,8 +155,8 @@ class WCSGeometry:
         >>> skycoord = SkyCoord(10, 20, unit='deg')
         >>> wcs_geometry = WCSGeometry.create_simple(
         ...     skydir=SkyCoord(0, 0, unit='deg', frame='galactic'),
-        ...     width=2000, height=1000, fov="3 deg",
-        ...     coordsys='galactic', projection='AIT'
+        ...     width=2000, height=1000, fov='3 deg',
+        ...     coordsys='galactic', projection='AIT',
         ... )
         >>> wcs_geometry.wcs
         Number of WCS axes: 2


### PR DESCRIPTION
This pull request:

- [x] Introduces `hips.tile.io` as the place where the default HiPS URL and filename are computed
- [x] Exposes the default URL in a (hopefully) slightly simpler and better way on the existing `HipsTileMeta` and `HipsSurveyProperties` classes.
- [x] Change tile I/O to store raw bytes and use that byte buffer in read / write calls, delaying the extraction of the pixels as a Numpy array to a `tile.data` property access.
- [x] Activate test that shows that FITS / JPG and PNG tile read / write now works and roundtrips.
- [x] Misc code / test / docs cleanup
