### PR TITLE
Fix tile_width property in HipsSurveyProperties class

### DIFF
--- a/hips/tiles/surveys.py
+++ b/hips/tiles/surveys.py
@@ -128,7 +128,10 @@ class HipsSurveyProperties:
     @property
     def tile_width(self) -> int:
         """HiPS tile width"""
-        return int(self.data['hips_tile_width']) or 512
+        try:
+            return int(self.data['hips_tile_width'])
+        except KeyError:
+            return 512
 
     @property
     def tile_format(self) -> str:


### PR DESCRIPTION
I encountered this issue when playing with certain surveys that are missing the `hips_tile_width` property key, such as this one (http://alasky.u-strasbg.fr/PLANCK/R2/HFI_Color_353_545_857/properties). They simply failed when I tried to access the property, this PR will fix this issue.