### PR TITLE
Add option to create HipsSurveyProperties from survey name

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -26,21 +26,16 @@ To draw a sky image from HiPS image tiles with the `hips` package, follow the fo
          coordsys='galactic', projection='AIT',
     )
 
-
-2. Specify the HiPS survey you want by creating a `~hips.HipsSurveyProperties` object.
+2. Specify the HiPS survey you want. You just need to provide a valid HiPS survey ID.
 
    A good address that lists available HiPS data is http://aladin.u-strasbg.fr/hips/list ::
 
-    from hips import HipsSurveyProperties
-    url = 'http://alasky.unistra.fr/DSS/DSS2Merged/properties'
-    hips_survey = HipsSurveyProperties.fetch(url)
-
+    hips_survey = 'CDS/P/DSS2/red'
 
 3. Call the `~hips.make_sky_image` function to fetch the HiPS data
    and draw it, returning an object of `~hips.HipsDrawResult`::
 
     from hips import make_sky_image
-
     result = make_sky_image(geometry, hips_survey, 'fits')
 
 Of course, you could change the parameters to chose any sky image geometry and

--- a/hips/draw/simple.py
+++ b/hips/draw/simple.py
@@ -4,7 +4,7 @@ import time
 import numpy as np
 from PIL import Image
 from astropy.io import fits
-from typing import List, Tuple
+from typing import List, Tuple, Union
 from astropy.wcs.utils import proj_plane_pixel_scales
 from skimage.transform import ProjectiveTransform, warp
 from ..tiles import HipsSurveyProperties, HipsTile, HipsTileMeta
@@ -61,7 +61,7 @@ class HipsPainter:
     (1000, 2000)
     """
 
-    def __init__(self, geometry: WCSGeometry, hips_survey: HipsSurveyProperties, tile_format: str) -> None:
+    def __init__(self, geometry: WCSGeometry, hips_survey: Union[str, HipsSurveyProperties], tile_format: str) -> None:
         self.geometry = geometry
         self.hips_survey = HipsSurveyProperties.make(hips_survey)
         self.tile_format = tile_format
@@ -382,7 +382,7 @@ def plot_mpl_single_tile(geometry: WCSGeometry, tile: HipsTile, image: np.ndarra
     ax.imshow(image, origin='lower')
 
 
-def make_sky_image(geometry: WCSGeometry, hips_survey: HipsSurveyProperties, tile_format: str) -> 'HipsDrawResult':
+def make_sky_image(geometry: WCSGeometry, hips_survey: Union[str, 'HipsSurveyProperties'], tile_format: str) -> 'HipsDrawResult':
     """Make sky image: fetch tiles and draw.
 
     The example for this can be found on the :ref:`gs` page.
@@ -399,8 +399,8 @@ def make_sky_image(geometry: WCSGeometry, hips_survey: HipsSurveyProperties, til
 
     Returns
     -------
-    image : `~numpy.ndarray`
-        Output image pixels
+    result : `~hips.HipsDrawResult`
+        Result object
     """
     painter = HipsPainter(geometry, hips_survey, tile_format)
     painter.run()

--- a/hips/tiles/surveys.py
+++ b/hips/tiles/surveys.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from io import StringIO
 from csv import DictWriter
 import urllib.request
-from typing import List
+from typing import List, Union
 from astropy.table import Table
 from .tile import HipsTileMeta
 
@@ -44,33 +44,22 @@ class HipsSurveyProperties:
     def __init__(self, data: OrderedDict) -> None:
         self.data = data
 
-    # TODO for Adeel: implement this (add docstring & test)
     @classmethod
-    def from_name(cls, name):
-        """
-        """
+    def from_name(cls, name: str) -> 'HipsSurveyProperties':
+        """Create object from Survey ID (`HipsSurveyProperties`)."""
         # TODO: implement some kind of caching for HipsSurveyPropertiesList
-        # Also update the getting started example to use this simple solution.
-        # Discuss with Thomas how to do it.
-        # See https://github.com/hipspy/hips/issues/81
         surveys = HipsSurveyPropertiesList.fetch()
-        for survey in surveys.data:
-            if survey.data['ID'].strip() == name.strip():
-                return survey
-
-        raise KeyError(f'Survey not found: {name}')
+        return surveys.from_name(name)
 
     @classmethod
-    def make(cls, hips_survey):
-        """Convenience constructor from string or existing object."""
-        return hips_survey
-        # TODO for Adeel: Implement the `HipsSurveyProperties.from_name` and add a test for this lookup by name
-        # if isinstance(hips_survey, str):
-        #     hips_survey = HipsSurveyProperties.from_name(hips_survey)
-        # elif isinstance(hips_survey, HipsSurveyProperties):
-        #     pass
-        # else:
-        #     raise TypeError(f'hips_survey must be str or HipsSurveyProperties. You gave {type(hips_survey)}')
+    def make(cls, hips_survey: Union[str, 'HipsSurveyProperties']) -> 'HipsSurveyProperties':
+        """Convenience constructor for from_string classmethod or existing object (`HipsSurveyProperties`)."""
+        if isinstance(hips_survey, str):
+            return HipsSurveyProperties.from_name(hips_survey)
+        elif isinstance(hips_survey, HipsSurveyProperties):
+            return hips_survey
+        else:
+            raise TypeError(f'hips_survey must be of type str or `HipsSurveyProperties`. You gave {type(hips_survey)}')
 
     @classmethod
     def read(cls, filename: str) -> 'HipsSurveyProperties':
@@ -294,3 +283,11 @@ class HipsSurveyPropertiesList:
         writer.writeheader()
         writer.writerows(rows)
         return Table.read(buffer.getvalue(), format='ascii.csv', guess=False)
+
+    def from_name(self, name: str) -> 'HipsSurveyProperties':
+        """Return a matching HiPS survey (`HipsSurveyProperties`)."""
+        for survey in self.data:
+            if survey.data['ID'].strip() == name.strip():
+                return survey
+
+        raise KeyError(f'Survey not found: {name}')


### PR DESCRIPTION
As outlined in #82 and during the telecon yesterday, I have added the option to create `HipsSurveyProperties` using a survey name.

@cdeil Currently, this is not implemented:

> 
> In addition, we might want to allow the geometry parameter in make_sky_image to be a dict, and if it is, call WCSGeometry.create_from_dict() for the user as a convenience. I.e. this would work:
> 
> ```
> geometry = dict(target='crab', fov='10 deg', frame='galactic')
> make_sky_image(geometry, hips_survey)
> 
> ```

Can this be part of a separate PR?