### PR TITLE
Add classmethod create_from_dict in WCSGeometry class

### DIFF
--- a/hips/draw/paint.py
+++ b/hips/draw/paint.py
@@ -26,7 +26,7 @@ class HipsPainter:
 
     Parameters
     ----------
-    geometry : `~hips.utils.WCSGeometry`
+    geometry : dict or `~hips.utils.WCSGeometry`
         An object of WCSGeometry
     hips_survey : str or `~hips.HipsSurveyProperties`
         HiPS survey properties
@@ -56,8 +56,8 @@ class HipsPainter:
     (1000, 2000)
     """
 
-    def __init__(self, geometry: WCSGeometry, hips_survey: Union[str, HipsSurveyProperties], tile_format: str, precise: bool = False) -> None:
-        self.geometry = geometry
+    def __init__(self, geometry: Union[dict, WCSGeometry], hips_survey: Union[str, HipsSurveyProperties], tile_format: str, precise: bool = False) -> None:
+        self.geometry = WCSGeometry.make(geometry)
         self.hips_survey = HipsSurveyProperties.make(hips_survey)
         self.tile_format = tile_format
         self.precise = precise

--- a/hips/draw/ui.py
+++ b/hips/draw/ui.py
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-def make_sky_image(geometry: WCSGeometry, hips_survey: Union[str, 'HipsSurveyProperties'],
+def make_sky_image(geometry: Union[dict, WCSGeometry], hips_survey: Union[str, 'HipsSurveyProperties'],
                    tile_format: str, precise: bool = False) -> 'HipsDrawResult':
     """Make sky image: fetch tiles and draw.
 
@@ -22,7 +22,7 @@ def make_sky_image(geometry: WCSGeometry, hips_survey: Union[str, 'HipsSurveyPro
 
     Parameters
     ----------
-    geometry : `~hips.utils.WCSGeometry`
+    geometry : dict or `~hips.utils.WCSGeometry`
         Geometry of the output image
     hips_survey : str or `~hips.HipsSurveyProperties`
         HiPS survey properties

--- a/hips/utils/tests/test_wcs.py
+++ b/hips/utils/tests/test_wcs.py
@@ -34,3 +34,11 @@ class TestWCSGeometry:
         assert_allclose(c.dec.deg, 0.00075, atol=1e-2)
         assert_allclose(self.geometry.wcs.wcs.crpix, [1000., 500.])
         assert_allclose(self.geometry.wcs.wcs.cdelt, [-0.0015, 0.0015])
+
+    def test_create_from_dict(self):
+        params = dict(target='crab', width=2000, height=1000, fov='3 deg',
+                      coordsys='galactic', projection='AIT')
+        geometry = WCSGeometry.create_from_dict(params)
+
+        c = self.geometry.center_skycoord
+        assert c.frame.name == 'galactic'

--- a/hips/utils/tests/test_wcs.py
+++ b/hips/utils/tests/test_wcs.py
@@ -40,5 +40,9 @@ class TestWCSGeometry:
                       coordsys='galactic', projection='AIT')
         geometry = WCSGeometry.create_from_dict(params)
 
-        c = self.geometry.center_skycoord
+        c = geometry.center_skycoord
         assert c.frame.name == 'galactic'
+        assert_allclose(c.l.deg, 184.55, atol=1e-2)
+        assert_allclose(c.b.deg, -5.78, atol=1e-2)
+        assert_allclose(self.geometry.wcs.wcs.crpix, [1000., 500.])
+        assert_allclose(self.geometry.wcs.wcs.cdelt, [-0.0015, 0.0015])

--- a/hips/utils/wcs.py
+++ b/hips/utils/wcs.py
@@ -158,6 +158,23 @@ class WCSGeometry:
 
         return cls(w, width, height)
 
+    @classmethod
+    def create_from_dict(cls, params: dict) -> 'WCSGeometry':
+        """Create WCS object from a dictionary (`WCSGeometry`)."""
+        skycoord = SkyCoord.from_name(params.pop('target'), frame=params['coordsys'])
+        # print(**params)
+        return cls.create(skycoord, **params)
+
+    @classmethod
+    def make(cls, geometry: Union[dict, 'WCSGeometry']) -> 'WCSGeometry':
+        """Convenience constructor for create_from_dict classmethod or existing object (`WCSGeometry`)."""
+        if isinstance(geometry, str):
+            return WCSGeometry.create_from_dict(geometry)
+        elif isinstance(geometry, WCSGeometry):
+            return geometry
+        else:
+            raise TypeError(f'geometry must be of type dict or `WCSGeometry`. You gave {type(geometry)}')
+
     @property
     def celestial_frame(self) -> str:
         """Celestial frame for the given WCS (str).


### PR DESCRIPTION
As @cdeil mentioned in #82, I have added a classmethod `create_from_dict` in `WCSGeometry` class. Now the user can pass either a `dict` or a `WCSGeometry` object itself. There is also a convenience method `make` in `WCSGeometry` which creates the object from `dict` parameters, if required. 