### PR TITLE
Add progress bar support for fetching and drawing HiPS tiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ matrix:
         # Run static code analysis
         - os: linux
           env: MAIN_CMD='make code-analysis' SETUP_CMD=''
-               PIP_DEPENDENCIES='mypy pycodestyle'
+               PIP_DEPENDENCIES='mypy pycodestyle tqdm'
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
-        - CONDA_DEPENDENCIES='healpy scikit-image Pillow reproject matplotlib'
+        - CONDA_DEPENDENCIES='healpy scikit-image Pillow reproject matplotlib tqdm'
         - PIP_DEPENDENCIES=''
         - CONDA_CHANNELS='conda-forge astropy-ci-extras astropy'
         - SETUP_XVFB=True
@@ -74,7 +74,7 @@ matrix:
         # Run static code analysis
         - os: linux
           env: MAIN_CMD='make code-analysis' SETUP_CMD=''
-               PIP_DEPENDENCIES='mypy pycodestyle tqdm'
+               PIP_DEPENDENCIES='mypy pycodestyle'
 
 
 install:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -33,7 +33,10 @@ To draw a sky image from HiPS image tiles with the `hips` package, follow the fo
     hips_survey = 'CDS/P/DSS2/red'
 
 3. Call the `~hips.make_sky_image` function to fetch the HiPS data
-   and draw it, returning an object of `~hips.HipsDrawResult`::
+   and draw it, returning an object of `~hips.HipsDrawResult`.
+   By default a progress bar is shown for fetching and
+   drawing HiPS tiles. For batch processing, this can be
+   turned off by passing a keyword argument: `progress_bar=False`::
 
     from hips import make_sky_image
     result = make_sky_image(geometry, hips_survey, 'fits')

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -79,5 +79,6 @@ The ``hips`` package has the following requirements:
 In addition, the following packages are needed for optional functionality:
 
 * `Matplotlib`_ 2.0 or later. Used for plotting in examples.
+* `tqdm`_ 4.15 or later. Used for showing progress bar either on terminal or in Jupyter notebook.
 
 We have some info at :ref:`py3` on why we don't support legacy Python (Python 2).

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -6,3 +6,4 @@
 .. _HiPS paper: https://www.aanda.org/articles/aa/pdf/2015/06/aa26075-15.pdf
 .. _HiPS IVOA recommendation: http://www.ivoa.net/documents/HiPS/
 .. _HiPS at CDS: http://aladin.u-strasbg.fr/hips/
+.. _tqdm: https://pypi.python.org/pypi/tqdm

--- a/hips/draw/paint.py
+++ b/hips/draw/paint.py
@@ -59,7 +59,7 @@ class HipsPainter:
     """
 
     def __init__(self, geometry: Union[dict, WCSGeometry], hips_survey: Union[str, HipsSurveyProperties],
-                 tile_format: str, precise: bool = False, progress_bar: bool = False) -> None:
+                 tile_format: str, precise: bool = False, progress_bar: bool = True) -> None:
         self.geometry = WCSGeometry.make(geometry)
         self.hips_survey = HipsSurveyProperties.make(hips_survey)
         self.tile_format = tile_format
@@ -113,7 +113,7 @@ class HipsPainter:
         """Generator function to fetch HiPS tiles from a remote URL."""
         if self.progress_bar:
             from tqdm import tqdm
-            tile_indices = tqdm(self.tile_indices, desc='Fetching tiles', disable=not self.progress_bar)
+            tile_indices = tqdm(self.tile_indices, desc='Fetching tiles')
         else:
             tile_indices = self.tile_indices
 
@@ -196,7 +196,7 @@ class HipsPainter:
         image = self._make_empty_sky_image()
         if self.progress_bar:
             from tqdm import tqdm
-            tiles = tqdm(self.draw_tiles, desc='Drawing tiles', disable=not self.progress_bar)
+            tiles = tqdm(self.draw_tiles, desc='Drawing tiles')
         else:
             tiles = self.draw_tiles
 

--- a/hips/draw/paint.py
+++ b/hips/draw/paint.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import time
 import numpy as np
-from tqdm import tqdm
 from typing import List, Tuple, Union, Dict, Any, Iterator
 from astropy.wcs.utils import proj_plane_pixel_scales
 from skimage.transform import ProjectiveTransform, warp
@@ -112,7 +111,13 @@ class HipsPainter:
 
     def _fetch_tiles(self) -> Iterator[HipsTile]:
         """Generator function to fetch HiPS tiles from a remote URL."""
-        for healpix_pixel_index in tqdm(self.tile_indices, desc='Fetching tiles', disable=not self.progress_bar):
+        if self.progress_bar:
+            from tqdm import tqdm
+            tile_indices = tqdm(self.tile_indices, desc='Fetching tiles', disable=not self.progress_bar)
+        else:
+            tile_indices = self.tile_indices
+
+        for healpix_pixel_index in tile_indices:
             tile_meta = HipsTileMeta(
                 order=self.draw_hips_order,
                 ipix=healpix_pixel_index,
@@ -189,8 +194,13 @@ class HipsPainter:
     def draw_all_tiles(self):
         """Make an empty sky image and draw all the tiles."""
         image = self._make_empty_sky_image()
+        if self.progress_bar:
+            from tqdm import tqdm
+            tiles = tqdm(self.draw_tiles, desc='Drawing tiles', disable=not self.progress_bar)
+        else:
+            tiles = self.draw_tiles
 
-        for tile in tqdm(self.draw_tiles, desc='Drawing tiles', disable=not self.progress_bar):
+        for tile in tiles:
             tile_image = self.warp_image(tile)
             # TODO: put better algorithm here instead of summing pixels
             # this can lead to pixels that are painted twice and become to bright

--- a/hips/draw/ui.py
+++ b/hips/draw/ui.py
@@ -15,7 +15,7 @@ __all__ = [
 
 
 def make_sky_image(geometry: Union[dict, WCSGeometry], hips_survey: Union[str, 'HipsSurveyProperties'],
-                   tile_format: str, precise: bool = False, progress_bar: bool = False) -> 'HipsDrawResult':
+                   tile_format: str, precise: bool = False, progress_bar: bool = True) -> 'HipsDrawResult':
     """Make sky image: fetch tiles and draw.
 
     The example for this can be found on the :ref:`gs` page.

--- a/hips/draw/ui.py
+++ b/hips/draw/ui.py
@@ -15,7 +15,7 @@ __all__ = [
 
 
 def make_sky_image(geometry: Union[dict, WCSGeometry], hips_survey: Union[str, 'HipsSurveyProperties'],
-                   tile_format: str, precise: bool = False) -> 'HipsDrawResult':
+                   tile_format: str, precise: bool = False, progress_bar: bool = False) -> 'HipsDrawResult':
     """Make sky image: fetch tiles and draw.
 
     The example for this can be found on the :ref:`gs` page.
@@ -31,13 +31,15 @@ def make_sky_image(geometry: Union[dict, WCSGeometry], hips_survey: Union[str, '
         (some surveys are available in several formats, so this extra argument is needed)
     precise : bool
         Use the precise drawing algorithm
+    progress_bar : bool
+        Show a progress bar for tile fetching and drawing
 
     Returns
     -------
     result : `~hips.HipsDrawResult`
         Result object
     """
-    painter = HipsPainter(geometry, hips_survey, tile_format, precise)
+    painter = HipsPainter(geometry, hips_survey, tile_format, precise, progress_bar)
     painter.run()
     return HipsDrawResult.from_painter(painter)
 

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ install_requires = [
 extras_require = dict(
     recommended=[
         'matplotlib>=2.0',
+        'tqdm>=4.15',
         'reproject>=0.3.1',
     ],
     develop=[

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ install_requires = [
 extras_require = dict(
     recommended=[
         'matplotlib>=2.0',
+
         'tqdm>=4.15',
         'reproject>=0.3.1',
     ],
@@ -113,6 +114,7 @@ extras_require = dict(
         'reproject>=0.3.1',
         'pytest>=3.0',
         'mypy>=0.501',
+        'tqdm>=4.15',
     ],
 )
 


### PR DESCRIPTION
As mentioned in #80, I have added a progress bar support for fetching and drawing HiPS tiles. The progress bar is off by default, the result can be seen in this notebook: https://github.com/adl1995/HIPS-to-Py/blob/master/examples/Precise%20drawing-ICRS.ipynb

To achieve this, I had to make use of the `tqdm` module.