### PR TITLE
Introduce asynchronous fetching of HiPS tiles

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -12,6 +12,7 @@ dependencies:
     - reproject
     - matplotlib
     - tqdm
+    - aiohttp
     # There's a problem with Sphinx 1.6 with astropy-helpers
     # For now, we pin the Sphinx version to something that works
     - sphinx==1.5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
-        - CONDA_DEPENDENCIES='healpy scikit-image Pillow reproject matplotlib tqdm'
+        - CONDA_DEPENDENCIES='healpy scikit-image Pillow reproject matplotlib tqdm aiohttp'
         - PIP_DEPENDENCIES=''
         - CONDA_CHANNELS='conda-forge astropy-ci-extras astropy'
         - SETUP_XVFB=True

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -80,5 +80,6 @@ In addition, the following packages are needed for optional functionality:
 
 * `Matplotlib`_ 2.0 or later. Used for plotting in examples.
 * `tqdm`_. Used for showing progress bar either on terminal or in Jupyter notebook.
+* `aiohttp`_. Used for fetching HiPS tiles.
 
 We have some info at :ref:`py3` on why we don't support legacy Python (Python 2).

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -7,3 +7,4 @@
 .. _HiPS IVOA recommendation: http://www.ivoa.net/documents/HiPS/
 .. _HiPS at CDS: http://aladin.u-strasbg.fr/hips/
 .. _tqdm: https://pypi.python.org/pypi/tqdm
+.. _aiohttp: http://aiohttp.readthedocs.io/en/stable/

--- a/hips/draw/paint.py
+++ b/hips/draw/paint.py
@@ -37,7 +37,8 @@ class HipsPainter:
     progress_bar : bool
         Show a progress bar for tile fetching and drawing
     fetch_opts : dict
-        Keyword arguments for fetching HiPS tiles
+        Keyword arguments for fetching HiPS tiles. To see the
+        list of passable arguments, refer to `~fetch_tiles`
 
     Examples
     --------
@@ -127,7 +128,7 @@ class HipsPainter:
 
         if self._tiles is None:
             self._tiles = fetch_tiles(tile_metas=tile_metas, hips_survey=self.hips_survey,
-                                      progress_bar=self.progress_bar, **self.fetch_opts)
+                                      progress_bar=self.progress_bar, **(self.fetch_opts or {}))
 
         return self._tiles
 

--- a/hips/draw/paint.py
+++ b/hips/draw/paint.py
@@ -6,7 +6,7 @@ import numpy as np
 from typing import List, Tuple, Union, Dict, Any, Generator
 from astropy.wcs.utils import proj_plane_pixel_scales
 from skimage.transform import ProjectiveTransform, warp
-from ..tiles import HipsSurveyProperties, HipsTile, HipsTileMeta
+from ..tiles import HipsSurveyProperties, HipsTile, HipsTileMeta, HipsTileFetcher
 from ..tiles.tile import compute_image_shape
 from ..utils import WCSGeometry, healpix_pixels_in_sky_image, hips_order_for_pixel_resolution
 
@@ -153,7 +153,8 @@ class HipsPainter:
     def tiles(self) -> List[HipsTile]:
         """List of `~hips.HipsTile` (cached on multiple access)."""
         if self._tiles is None:
-            self._tiles = asyncio.get_event_loop().run_until_complete(self._fetch_tiles())
+            # self._tiles = asyncio.get_event_loop().run_until_complete(tile_fetcher.tiles)
+            self._tiles = tile_fetcher.tiles
 
         return self._tiles
 

--- a/hips/draw/tests/test_paint.py
+++ b/hips/draw/tests/test_paint.py
@@ -20,7 +20,7 @@ class TestHipsPainter:
             width=2000, height=1000, fov="3 deg",
             coordsys='icrs', projection='AIT',
         )
-        cls.painter = HipsPainter(cls.geometry, cls.hips_survey, 'fits')
+        cls.painter = HipsPainter(cls.geometry, cls.hips_survey, 'fits', fetch_package='aiohttp')
 
     def test_draw_hips_order(self):
         assert self.painter.draw_hips_order == 7
@@ -43,7 +43,7 @@ class TestHipsPainter:
             coordsys='icrs', projection='AIT',
         )
 
-        simple_tile_painter = HipsPainter(geometry, self.hips_survey, 'fits')
+        simple_tile_painter = HipsPainter(geometry, self.hips_survey, 'fits', fetch_package='aiohttp')
         assert simple_tile_painter.draw_hips_order == pars['order']
 
     def test_run(self):

--- a/hips/draw/tests/test_paint.py
+++ b/hips/draw/tests/test_paint.py
@@ -20,7 +20,8 @@ class TestHipsPainter:
             width=2000, height=1000, fov="3 deg",
             coordsys='icrs', projection='AIT',
         )
-        cls.painter = HipsPainter(cls.geometry, cls.hips_survey, 'fits', fetch_package='aiohttp')
+        fetch_opts = dict(fetch_package='urllib', timeout=30, n_parallel=10)
+        cls.painter = HipsPainter(cls.geometry, cls.hips_survey, 'fits', fetch_opts=fetch_opts)
 
     def test_draw_hips_order(self):
         assert self.painter.draw_hips_order == 7
@@ -43,7 +44,8 @@ class TestHipsPainter:
             coordsys='icrs', projection='AIT',
         )
 
-        simple_tile_painter = HipsPainter(geometry, self.hips_survey, 'fits', fetch_package='aiohttp')
+        fetch_opts = dict(fetch_package='urllib', timeout=30, n_parallel=10)
+        simple_tile_painter = HipsPainter(geometry, self.hips_survey, 'fits', fetch_opts=fetch_opts)
         assert simple_tile_painter.draw_hips_order == pars['order']
 
     def test_run(self):

--- a/hips/draw/tests/test_ui.py
+++ b/hips/draw/tests/test_ui.py
@@ -61,7 +61,9 @@ def test_make_sky_image(tmpdir, pars):
     hips_survey = HipsSurveyProperties.fetch(url=pars['url'])
     geometry = make_test_wcs_geometry()
 
-    result = make_sky_image(geometry=geometry, hips_survey=hips_survey, tile_format=pars['file_format'], precise=pars['precise'])
+    fetch_opts = dict(fetch_package='urllib', timeout=30, n_parallel=10)
+    result = make_sky_image(geometry=geometry, hips_survey=hips_survey, tile_format=pars['file_format'],
+                            precise=pars['precise'], fetch_opts=fetch_opts)
 
     assert result.image.shape == pars['shape']
     assert result.image.dtype == pars['dtype']

--- a/hips/draw/ui.py
+++ b/hips/draw/ui.py
@@ -15,7 +15,7 @@ __all__ = [
 
 
 def make_sky_image(geometry: Union[dict, WCSGeometry], hips_survey: Union[str, 'HipsSurveyProperties'],
-                   tile_format: str, precise: bool = False, progress_bar: bool = True) -> 'HipsDrawResult':
+                   tile_format: str, precise: bool = False, progress_bar: bool = True, fetch_package: str = 'urllib') -> 'HipsDrawResult':
     """Make sky image: fetch tiles and draw.
 
     The example for this can be found on the :ref:`gs` page.
@@ -33,13 +33,15 @@ def make_sky_image(geometry: Union[dict, WCSGeometry], hips_survey: Union[str, '
         Use the precise drawing algorithm
     progress_bar : bool
         Show a progress bar for tile fetching and drawing
+    fetch_package : {'urllib', 'aiohttp'}
+        Package to use for fetching HiPS tiles
 
     Returns
     -------
     result : `~hips.HipsDrawResult`
         Result object
     """
-    painter = HipsPainter(geometry, hips_survey, tile_format, precise, progress_bar)
+    painter = HipsPainter(geometry, hips_survey, tile_format, precise, progress_bar, fetch_package)
     painter.run()
     return HipsDrawResult.from_painter(painter)
 

--- a/hips/draw/ui.py
+++ b/hips/draw/ui.py
@@ -34,7 +34,8 @@ def make_sky_image(geometry: Union[dict, WCSGeometry], hips_survey: Union[str, '
     progress_bar : bool
         Show a progress bar for tile fetching and drawing
     fetch_opts : dict
-        Keyword arguments for fetching HiPS tiles
+        Keyword arguments for fetching HiPS tiles. To see the
+        list of passable arguments, refer to `~hips.fetch_tiles`
 
     Returns
     -------

--- a/hips/draw/ui.py
+++ b/hips/draw/ui.py
@@ -15,7 +15,7 @@ __all__ = [
 
 
 def make_sky_image(geometry: Union[dict, WCSGeometry], hips_survey: Union[str, 'HipsSurveyProperties'],
-                   tile_format: str, precise: bool = False, progress_bar: bool = True, fetch_package: str = 'urllib') -> 'HipsDrawResult':
+                   tile_format: str, precise: bool = False, progress_bar: bool = True, fetch_opts: dict = None) -> 'HipsDrawResult':
     """Make sky image: fetch tiles and draw.
 
     The example for this can be found on the :ref:`gs` page.
@@ -33,15 +33,15 @@ def make_sky_image(geometry: Union[dict, WCSGeometry], hips_survey: Union[str, '
         Use the precise drawing algorithm
     progress_bar : bool
         Show a progress bar for tile fetching and drawing
-    fetch_package : {'urllib', 'aiohttp'}
-        Package to use for fetching HiPS tiles
+    fetch_opts : dict
+        Keyword arguments for fetching HiPS tiles
 
     Returns
     -------
     result : `~hips.HipsDrawResult`
         Result object
     """
-    painter = HipsPainter(geometry, hips_survey, tile_format, precise, progress_bar, fetch_package)
+    painter = HipsPainter(geometry, hips_survey, tile_format, precise, progress_bar, fetch_opts)
     painter.run()
     return HipsDrawResult.from_painter(painter)
 

--- a/hips/tiles/__init__.py
+++ b/hips/tiles/__init__.py
@@ -3,3 +3,4 @@
 from .tile import *
 from .survey import *
 from .allsky import *
+from .fetch import *

--- a/hips/tiles/fetch.py
+++ b/hips/tiles/fetch.py
@@ -1,17 +1,22 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import numpy as np
+import asyncio
 import urllib.request
 import concurrent.futures
 from typing import Generator, List
 from ..tiles import HipsSurveyProperties, HipsTile, HipsTileMeta
 
 __all__ = [
-    'HipsTileFetcher',
+    'fetch_tiles',
 ]
 
-
-class HipsTileFetcher:
+def fetch_tiles(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperties,
+                progress_bar: bool = False, n_parallel: int = 10,  timeout: int = 10, fetch_package : str = 'urllib') -> List[HipsTile]:
     """Fetch a list of HiPS tiles.
+
+    This function fetches a list of HiPS tiles based
+    on their URLs, which are generated using `hips_survey`
+    and `tile_metas`. The tiles are then fetched asynchronously
+    using urllib or aiohttp.
 
     Parameters
     ----------
@@ -28,86 +33,72 @@ class HipsTileFetcher:
     fetch_package : {'urllib', 'aiohttp'}
         Package to use for fetching HiPS tiles
     """
+    if fetch_package == 'aiohttp':
+        return tiles_aiohttp(tile_metas, hips_survey, progress_bar)
+    elif fetch_package == 'urllib':
+        return tiles_urllib(tile_metas, hips_survey, progress_bar, n_parallel, timeout)
+    else:
+        raise ValueError(f'Invalid package name: {fetch_package}')
 
-    def __init__(self, tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperties,
-                 progress_bar: bool = False, n_parallel: int = 10,  timeout: int = 10, fetch_package : str = 'urllib') -> None:
-        self.tile_metas = tile_metas
-        self.hips_survey = hips_survey
-        self.progress_bar = progress_bar
-        self.n_parallel = n_parallel
-        self.timeout = timeout
-        self.fetch_package = fetch_package
+def tile_urls(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperties) -> List[str]:
+    """List of tile URLs"""
+    return [hips_survey.tile_url(meta) for meta in tile_metas]
 
-    @property
-    def tile_urls(self) -> List[str]:
-        """List of tile URLs"""
-        tile_urls = []
-        for meta in self.tile_metas:
-            tile_urls.append(self.hips_survey.tile_url(meta))
+def fetch_tile_urllib(url: str, meta: HipsTileMeta, timeout: int) -> Generator:
+    """Fetch a HiPS tile asynchronously."""
+    with urllib.request.urlopen(url, timeout=timeout) as conn:
+        raw_data = conn.read()
+        return HipsTile(meta, raw_data)
 
-        return tile_urls
+def tiles_urllib(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperties,
+                 progress_bar: bool = False, n_parallel: int = 10,  timeout: int = 10) -> List[HipsTile]:
+    """Generator function to fetch HiPS tiles from a remote URL."""
+    with concurrent.futures.ThreadPoolExecutor(max_workers=n_parallel) as executor:
+        future_to_url = {executor.submit(
+            fetch_tile_urllib,
+            url,
+            tile_metas[idx],
+            timeout)
+            : url for idx, url in enumerate(tile_urls(tile_metas, hips_survey))}
 
-    @property
-    def tiles(self):
-        if self.fetch_package == 'aiohttp':
-            return self.tiles_aiohttp
-        elif self.fetch_package == 'urllib':
-            return self.tiles_urllib
+        if progress_bar:
+            from tqdm import tqdm
+            requests = tqdm(future_to_url, total=len(future_to_url), desc='Fetching tiles')
         else:
-            raise ValueError(f'Invalid package name: {self.fetch_package}')
+            requests = future_to_url
 
-    def fetch_tile_urllib(self, url: str, meta : HipsTileMeta) -> Generator:
-        """Fetch a HiPS tile asynchronously."""
-        with urllib.request.urlopen(url, timeout=self.timeout) as conn:
-            raw_data = conn.read()
-            return HipsTile(meta, raw_data)
+        tiles = []
+        for request in requests:
+            tiles.append(request.result())
 
-    @property
-    def tiles_urllib(self) -> np.ndarray:
-        """Generator function to fetch HiPS tiles from a remote URL."""
-        with concurrent.futures.ThreadPoolExecutor(max_workers=self.n_parallel) as executor:
-            future_to_url = {executor.submit(self.fetch_tile_urllib, url, self.tile_metas[idx]) : url for idx, url in enumerate(self.tile_urls)}
+    return tiles
 
-            if self.progress_bar:
-                from tqdm import tqdm
-                requests = tqdm(concurrent.futures.as_completed(future_to_url), total=len(future_to_url), desc='Fetching tiles')
-            else:
-                requests = future_to_url#concurrent.futures.as_completed(future_to_url)
+async def fetch_tile_aiohttp(url: str, meta : HipsTileMeta, session) -> Generator:
+    """Fetch a HiPS tile asynchronously using aiohttp."""
+    async with session.get(url) as response:
+        raw_data = await response.read()
+        return HipsTile(meta, raw_data)
 
+async def fetch_all_tiles_aiohttp(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperties, progress_bar: bool) -> List[HipsTile]:
+    """Generator function to fetch HiPS tiles from a remote URL using aiohttp."""
+    import aiohttp
+
+    tasks = []
+    async with aiohttp.ClientSession() as session:
+        for idx, url in enumerate(tile_urls(tile_metas, hips_survey)):
+            task = asyncio.ensure_future(fetch_tile_aiohttp(url.format(idx), tile_metas[idx], session))
+            tasks.append(task)
+
+        if progress_bar:
+            from tqdm import tqdm
             tiles = []
-            for future in requests:
-                tiles.append(future.result())
+            for f in tqdm(tasks, total=len(tasks), desc='Fetching tiles'):
+                tiles.append(await f)
+        else:
+            tiles = await asyncio.gather(*tasks)
 
-        return tiles
+    return tiles
 
-    async def fetch_tile_aiohttp(self, url: str, meta : HipsTileMeta, session) -> Generator:
-        """Fetch a HiPS tile asynchronously using aiohttp."""
-        async with session.get(url) as response:
-            raw_data = await response.read()
-            return HipsTile(meta, raw_data)
-
-    @property
-    async def fetch_all_tiles_aiohttp(self) -> np.ndarray:
-        """Generator function to fetch HiPS tiles from a remote URL using aiohttp."""
-        import aiohttp, asyncio
-
-        tasks = []
-        async with aiohttp.ClientSession() as session:
-            for idx, url in enumerate(self.tile_urls):
-                task = asyncio.ensure_future(self.fetch_tile_aiohttp(url.format(idx), self.tile_metas[idx], session))
-                tasks.append(task)
-
-            if self.progress_bar:
-                from tqdm import tqdm
-                tiles = []
-                for f in tqdm(tasks, total=len(tasks), desc='Fetching tiles'):
-                    tiles.append(await f)
-            else:
-                tiles = await asyncio.gather(*tasks)
-
-        return tiles
-
-    @property
-    def tiles_aiohttp(self) -> np.ndarray:
-        import asyncio
-        return asyncio.get_event_loop().run_until_complete(self.fetch_all_tiles_aiohttp)
+def tiles_aiohttp(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperties,
+                  progress_bar: bool) -> List[HipsTile]:
+    return asyncio.get_event_loop().run_until_complete(fetch_all_tiles_aiohttp(tile_metas, hips_survey, progress_bar))

--- a/hips/tiles/fetch.py
+++ b/hips/tiles/fetch.py
@@ -14,15 +14,16 @@ __doctest_skip__ = [
 ]
 
 
-def fetch_tiles(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperties,
+def fetch_tiles(tile_metas: List[HipsTileMeta], hips_survey: HipsSurveyProperties,
                 progress_bar: bool = False, n_parallel: int = 10,
-                timeout: float = 10, fetch_package : str = 'urllib') -> List[HipsTile]:
+                timeout: float = 10, fetch_package: str = 'urllib') -> List[HipsTile]:
     """Fetch a list of HiPS tiles.
 
     This function fetches a list of HiPS tiles based
-    on their URLs, which are generated using `hips_survey`
-    and `tile_metas`. The tiles are then fetched asynchronously
-    using urllib or aiohttp.
+    on their URLs, which are generated using ``hips_survey``
+    and ``tile_metas``.
+
+    The tiles are then fetched asynchronously using ``urllib`` or ``aiohttp``.
 
     Parameters
     ----------
@@ -41,25 +42,26 @@ def fetch_tiles(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperti
 
     Examples
     --------
-    >>> from hips import HipsSurveyProperties
-    >>> from hips import fetch_tiles
-    >>> url = 'http://alasky.unistra.fr/DSS/DSS2Merged/properties'
-    >>> hips_survey = HipsSurveyProperties.fetch(url)
-    >>> tile_indices = [69623, 69627, 69628, 69629, 69630, 69631]
-    >>> tile_metas = []
-    >>> for healpix_pixel_index in tile_indices:
-    ...    tile_meta = HipsTileMeta(
-    ...        order=7,
-    ...        ipix=healpix_pixel_index,
-    ...        frame=hips_survey.astropy_frame,
-    ...        file_format='fits',
-    ...    )
-    ...    tile_metas.append(tile_meta)
-    >>> tiles = fetch_tiles(tile_metas, hips_survey)
-    >>> tiles[0].meta.file_format
-    fits
-    >>> tiles[0].meta.order
-    7
+    Define a list of tiles we want::
+
+        from hips import HipsSurveyProperties, HipsTileMeta
+        from hips import fetch_tiles
+        url = 'http://alasky.unistra.fr/DSS/DSS2Merged/properties'
+        hips_survey = HipsSurveyProperties.fetch(url)
+        tile_indices = [69623, 69627, 69628, 69629, 69630, 69631]
+        tile_metas = []
+        for healpix_pixel_index in tile_indices:
+            tile_meta = HipsTileMeta(
+               order=7,
+               ipix=healpix_pixel_index,
+               frame=hips_survey.astropy_frame,
+               file_format='fits',
+           )
+           tile_metas.append(tile_meta)
+
+    Fetch all tiles (in parallel)::
+
+        tiles = fetch_tiles(tile_metas, hips_survey)
 
     Returns
     -------
@@ -67,11 +69,25 @@ def fetch_tiles(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperti
         A Python list of HiPS tiles
     """
     if fetch_package == 'aiohttp':
-        return tiles_aiohttp(tile_metas, hips_survey, progress_bar)
+        fetch_fct = tiles_aiohttp
     elif fetch_package == 'urllib':
-        return tiles_urllib(tile_metas, hips_survey, progress_bar, n_parallel, timeout)
+        fetch_fct = tiles_urllib
     else:
         raise ValueError(f'Invalid package name: {fetch_package}')
+
+    tiles = fetch_fct(tile_metas, hips_survey, progress_bar, n_parallel, timeout)
+
+    # Sort tiles to match the tile_meta list
+    # TODO: this doesn't seem like a great solution.
+    # Use OrderedDict instead?
+    out = []
+    for tile_meta in tile_metas:
+        for tile in tiles:
+            if tile.meta == tile_meta:
+                out.append(tile)
+                continue
+    return out
+
 
 def fetch_tile_urllib(url: str, meta: HipsTileMeta, timeout: float) -> Generator:
     """Fetch a HiPS tile asynchronously."""
@@ -79,35 +95,38 @@ def fetch_tile_urllib(url: str, meta: HipsTileMeta, timeout: float) -> Generator
         raw_data = conn.read()
         return HipsTile(meta, raw_data)
 
-def tiles_urllib(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperties,
-                 progress_bar: bool = False, n_parallel: int = 10,  timeout: float = 10) -> List[HipsTile]:
+
+def tiles_urllib(tile_metas: List[HipsTileMeta], hips_survey: HipsSurveyProperties,
+                 progress_bar: bool = False, n_parallel: int = 10, timeout: float = 10) -> List[HipsTile]:
     """Generator function to fetch HiPS tiles from a remote URL."""
     with concurrent.futures.ThreadPoolExecutor(max_workers=n_parallel) as executor:
         futures = []
         for meta in tile_metas:
             url = hips_survey.tile_url(meta)
-            futures.append(executor.submit(fetch_tile_urllib, url, meta, timeout))
+            future = executor.submit(fetch_tile_urllib, url, meta, timeout)
+            futures.append(future)
 
+        futures = concurrent.futures.as_completed(futures)
         if progress_bar:
-            from tqdm import tqdm as progress_bar
-        else:
-            def progress_bar(*args):
-                return args[0]
+            from tqdm import tqdm
+            futures = tqdm(futures, total=len(tile_metas), desc='Fetching tiles')
 
         tiles = []
-        for future in progress_bar(concurrent.futures.as_completed(futures), total=len(futures), desc='Fetching tiles'):
+        for future in futures:
             tiles.append(future.result())
 
     return tiles
 
-async def fetch_tile_aiohttp(url: str, meta : HipsTileMeta, session) -> Generator:
+
+async def fetch_tile_aiohttp(url: str, meta: HipsTileMeta, session) -> Generator:
     """Fetch a HiPS tile asynchronously using aiohttp."""
     async with session.get(url) as response:
         raw_data = await response.read()
         return HipsTile(meta, raw_data)
 
+
 async def fetch_all_tiles_aiohttp(tile_metas: List[HipsTileMeta],
-                                  hips_survey : HipsSurveyProperties, progress_bar: bool) -> List[HipsTile]:
+                                  hips_survey: HipsSurveyProperties, progress_bar: bool) -> List[HipsTile]:
     """Generator function to fetch HiPS tiles from a remote URL using aiohttp."""
     import aiohttp
 
@@ -115,22 +134,24 @@ async def fetch_all_tiles_aiohttp(tile_metas: List[HipsTileMeta],
         futures = []
         for meta in tile_metas:
             url = hips_survey.tile_url(meta)
-            futures.append(asyncio.ensure_future(fetch_tile_aiohttp(url, meta, session)))
+            future = asyncio.ensure_future(fetch_tile_aiohttp(url, meta, session))
+            futures.append(future)
 
+        futures = asyncio.as_completed(futures)
         if progress_bar:
-            from tqdm import tqdm as progress_bar
-        else:
-            def progress_bar(*args):
-                return args[0]
+            from tqdm import tqdm
+            futures = tqdm(futures, total=len(tile_metas), desc='Fetching tiles')
 
         tiles = []
-        for future in progress_bar(asyncio.as_completed(futures), total=len(futures), desc='Fetching tiles'):
+        for future in futures:
             tiles.append(await future)
 
     return tiles
 
-def tiles_aiohttp(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperties,
-                  progress_bar: bool) -> List[HipsTile]:
+
+def tiles_aiohttp(tile_metas: List[HipsTileMeta], hips_survey: HipsSurveyProperties,
+                  progress_bar: bool, n_parallel: int = 10, timeout: float = 10) -> List[HipsTile]:
+    # TODO: implement n_parallel and timeout
     return asyncio.get_event_loop().run_until_complete(
         fetch_all_tiles_aiohttp(tile_metas, hips_survey, progress_bar)
     )

--- a/hips/tiles/fetch.py
+++ b/hips/tiles/fetch.py
@@ -9,8 +9,14 @@ __all__ = [
     'fetch_tiles',
 ]
 
+__doctest_skip__ = [
+    'fetch_tiles',
+]
+
+
 def fetch_tiles(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperties,
-                progress_bar: bool = False, n_parallel: int = 10,  timeout: int = 10, fetch_package : str = 'urllib') -> List[HipsTile]:
+                progress_bar: bool = False, n_parallel: int = 10,
+                timeout: float = 10, fetch_package : str = 'urllib') -> List[HipsTile]:
     """Fetch a list of HiPS tiles.
 
     This function fetches a list of HiPS tiles based
@@ -28,10 +34,37 @@ def fetch_tiles(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperti
         Show a progress bar for tile fetching and drawing
     n_parallel : int
         Number of threads to use for fetching HiPS tiles
-    timeout : int
+    timeout : float
         Seconds to timeout for fetching a HiPS tile
     fetch_package : {'urllib', 'aiohttp'}
         Package to use for fetching HiPS tiles
+
+    Examples
+    --------
+    >>> from hips import HipsSurveyProperties
+    >>> from hips import fetch_tiles
+    >>> url = 'http://alasky.unistra.fr/DSS/DSS2Merged/properties'
+    >>> hips_survey = HipsSurveyProperties.fetch(url)
+    >>> tile_indices = [69623, 69627, 69628, 69629, 69630, 69631]
+    >>> tile_metas = []
+    >>> for healpix_pixel_index in tile_indices:
+    ...    tile_meta = HipsTileMeta(
+    ...        order=7,
+    ...        ipix=healpix_pixel_index,
+    ...        frame=hips_survey.astropy_frame,
+    ...        file_format='fits',
+    ...    )
+    ...    tile_metas.append(tile_meta)
+    >>> tiles = fetch_tiles(tile_metas, hips_survey)
+    >>> tiles[0].meta.file_format
+    fits
+    >>> tiles[0].meta.order
+    7
+
+    Returns
+    -------
+    tiles : List[HipsTile]
+        A Python list of HiPS tiles
     """
     if fetch_package == 'aiohttp':
         return tiles_aiohttp(tile_metas, hips_survey, progress_bar)
@@ -40,36 +73,30 @@ def fetch_tiles(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperti
     else:
         raise ValueError(f'Invalid package name: {fetch_package}')
 
-def tile_urls(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperties) -> List[str]:
-    """List of tile URLs"""
-    return [hips_survey.tile_url(meta) for meta in tile_metas]
-
-def fetch_tile_urllib(url: str, meta: HipsTileMeta, timeout: int) -> Generator:
+def fetch_tile_urllib(url: str, meta: HipsTileMeta, timeout: float) -> Generator:
     """Fetch a HiPS tile asynchronously."""
     with urllib.request.urlopen(url, timeout=timeout) as conn:
         raw_data = conn.read()
         return HipsTile(meta, raw_data)
 
 def tiles_urllib(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperties,
-                 progress_bar: bool = False, n_parallel: int = 10,  timeout: int = 10) -> List[HipsTile]:
+                 progress_bar: bool = False, n_parallel: int = 10,  timeout: float = 10) -> List[HipsTile]:
     """Generator function to fetch HiPS tiles from a remote URL."""
     with concurrent.futures.ThreadPoolExecutor(max_workers=n_parallel) as executor:
-        future_to_url = {executor.submit(
-            fetch_tile_urllib,
-            url,
-            tile_metas[idx],
-            timeout)
-            : url for idx, url in enumerate(tile_urls(tile_metas, hips_survey))}
+        futures = []
+        for meta in tile_metas:
+            url = hips_survey.tile_url(meta)
+            futures.append(executor.submit(fetch_tile_urllib, url, meta, timeout))
 
         if progress_bar:
-            from tqdm import tqdm
-            requests = tqdm(future_to_url, total=len(future_to_url), desc='Fetching tiles')
+            from tqdm import tqdm as progress_bar
         else:
-            requests = future_to_url
+            def progress_bar(*args):
+                return args[0]
 
         tiles = []
-        for request in requests:
-            tiles.append(request.result())
+        for future in progress_bar(concurrent.futures.as_completed(futures), total=len(futures), desc='Fetching tiles'):
+            tiles.append(future.result())
 
     return tiles
 
@@ -79,26 +106,31 @@ async def fetch_tile_aiohttp(url: str, meta : HipsTileMeta, session) -> Generato
         raw_data = await response.read()
         return HipsTile(meta, raw_data)
 
-async def fetch_all_tiles_aiohttp(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperties, progress_bar: bool) -> List[HipsTile]:
+async def fetch_all_tiles_aiohttp(tile_metas: List[HipsTileMeta],
+                                  hips_survey : HipsSurveyProperties, progress_bar: bool) -> List[HipsTile]:
     """Generator function to fetch HiPS tiles from a remote URL using aiohttp."""
     import aiohttp
 
-    tasks = []
     async with aiohttp.ClientSession() as session:
-        for idx, url in enumerate(tile_urls(tile_metas, hips_survey)):
-            task = asyncio.ensure_future(fetch_tile_aiohttp(url.format(idx), tile_metas[idx], session))
-            tasks.append(task)
+        futures = []
+        for meta in tile_metas:
+            url = hips_survey.tile_url(meta)
+            futures.append(asyncio.ensure_future(fetch_tile_aiohttp(url, meta, session)))
 
         if progress_bar:
-            from tqdm import tqdm
-            tiles = []
-            for f in tqdm(tasks, total=len(tasks), desc='Fetching tiles'):
-                tiles.append(await f)
+            from tqdm import tqdm as progress_bar
         else:
-            tiles = await asyncio.gather(*tasks)
+            def progress_bar(*args):
+                return args[0]
+
+        tiles = []
+        for future in progress_bar(asyncio.as_completed(futures), total=len(futures), desc='Fetching tiles'):
+            tiles.append(await future)
 
     return tiles
 
 def tiles_aiohttp(tile_metas: List[HipsTileMeta], hips_survey : HipsSurveyProperties,
                   progress_bar: bool) -> List[HipsTile]:
-    return asyncio.get_event_loop().run_until_complete(fetch_all_tiles_aiohttp(tile_metas, hips_survey, progress_bar))
+    return asyncio.get_event_loop().run_until_complete(
+        fetch_all_tiles_aiohttp(tile_metas, hips_survey, progress_bar)
+    )

--- a/hips/tiles/fetch.py
+++ b/hips/tiles/fetch.py
@@ -1,0 +1,118 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import aiohttp
+import asyncio
+import urllib.request
+import concurrent.futures
+import numpy as np
+from typing import Generator
+from ..tiles import HipsSurveyProperties, HipsTile, HipsTileMeta
+
+__all__ = [
+    'HipsTileFetcher',
+]
+
+__doctest_skip__ = [
+    'HipsTileFetcher',
+]
+
+
+class HipsTileFetcher:
+    """Fetch a list of HiPS tiles.
+
+    Parameters
+    ----------
+    geometry : dict or `~hips.utils.WCSGeometry`
+        An object of WCSGeometry
+    hips_survey : str or `~hips.HipsSurveyProperties`
+        HiPS survey properties
+    tile_format : {'fits', 'jpg', 'png'}
+        Format of HiPS tile
+    precise : bool
+        Use the precise drawing algorithm
+    """
+
+    def __init__(self, tile_indices: np.ndarray, hips_order: int, hips_survey: HipsSurveyProperties, tile_format: str,
+                 progress_bar: bool, use_aiohttp: bool) -> None:
+        self.tile_indices = tile_indices
+        self.hips_order = hips_order
+        self.hips_survey = hips_survey
+        self.tile_format = tile_format
+
+    def fetch_tile_threaded(self, url: str, session: aiohttp.client.ClientSession) -> Generator:
+        """Fetch a HiPS tile asynchronously."""
+        with urllib.request.urlopen(url, timeout=60) as conn:
+            return conn.read()
+
+    @property
+    def tiles(self) -> np.ndarray:
+        """Generator function to fetch HiPS tiles from a remote URL."""
+        tile_urls, tile_metas = [], []
+        for healpix_pixel_index in self.tile_indices:
+            tile_meta = HipsTileMeta(
+                order=self.hips_order,
+                ipix=healpix_pixel_index,
+                frame=self.hips_survey.astropy_frame,
+                file_format=self.tile_format,
+            )
+            tile_urls.append(self.hips_survey.tile_url(tile_meta))
+            tile_metas.append(tile_meta)
+
+        raw_responses = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+            # Start the load operations and mark each future with its URL
+            future_to_url = {executor.submit(self.fetch_tile_threaded, url, 60): url for url in tile_urls}
+            for future in concurrent.futures.as_completed(future_to_url):
+                url = future_to_url[future]
+                # try:
+                raw_responses.append(future.result())
+                # except Exception as exc:
+                #     print('%r generated an exception: %s' % (url, exc))
+                # else:
+                #     print('%r page is %d bytes' % (url, len(future.result())))
+
+
+        #
+        # tasks = []
+        # async with aiohttp.ClientSession() as session:
+        #     for idx, url in enumerate(tile_urls):
+        #         task = asyncio.ensure_future(self.fetch_tile_threaded(url.format(idx), session))
+        #         tasks.append(task)
+        #
+        #     raw_responses = await asyncio.gather(*tasks)
+        #
+        tiles = []
+        for idx, raw_data in enumerate(raw_responses):
+            tiles.append(HipsTile(tile_metas[idx], raw_data))
+        return tiles
+
+    # async def fetch_tile_threaded(self, url: str, session: aiohttp.client.ClientSession) -> Generator:
+    #     """Fetch a HiPS tile asynchronously."""
+    #     async with session.get(url) as response:
+    #         return await response.read()
+    #
+    # @property
+    # async def tiles(self) -> np.ndarray:
+    #     """Generator function to fetch HiPS tiles from a remote URL."""
+    #     tile_urls, tile_metas = [], []
+    #     for healpix_pixel_index in self.tile_indices:
+    #         tile_meta = HipsTileMeta(
+    #             order=self.hips_order,
+    #             ipix=healpix_pixel_index,
+    #             frame=self.hips_survey.astropy_frame,
+    #             file_format=self.tile_format,
+    #         )
+    #         tile_urls.append(self.hips_survey.tile_url(tile_meta))
+    #         tile_metas.append(tile_meta)
+    #
+    #     tasks = []
+    #     async with aiohttp.ClientSession() as session:
+    #         for idx, url in enumerate(tile_urls):
+    #             task = asyncio.ensure_future(self.fetch_tile_threaded(url.format(idx), session))
+    #             tasks.append(task)
+    #
+    #         raw_responses = await asyncio.gather(*tasks)
+    #
+    #     tiles = []
+    #     for idx, raw_data in enumerate(raw_responses):
+    #         tiles.append(HipsTile(tile_metas[idx], raw_data))
+    #     return tiles

--- a/hips/tiles/tests/test_fetch.py
+++ b/hips/tiles/tests/test_fetch.py
@@ -8,24 +8,34 @@ from ..tile import HipsTileMeta
 
 TILE_FETCH_TEST_CASES = [
     dict(
-        tile_indices=[69623],
+        tile_indices=[69623, 69627, 69628, 69629, 69630, 69631],
         tile_format='fits',
         order=7,
         url='http://alasky.unistra.fr/DSS/DSS2Merged/properties',
         progress_bar=True,
-        data=[2101, 1680, 1532, 1625, 2131],
-        fetch_package='urllib'
+        data=[2101, 1945, 1828, 1871, 2079, 2336],
+        fetch_package='urllib',
     ),
     dict(
-        tile_indices=[69623],
+        tile_indices=[69623, 69627, 69628, 69629, 69630, 69631],
         tile_format='fits',
         order=7,
         url='http://alasky.unistra.fr/DSS/DSS2Merged/properties',
         progress_bar=True,
-        data=[2101, 1680, 1532, 1625, 2131],
-        fetch_package='aiohttp'
+        data=[2101, 1945, 1828, 1871, 2079, 2336],
+        fetch_package='aiohttp',
     ),
 ]
+
+
+def make_tile_metas(hips_survey, pars):
+    for healpix_pixel_index in pars['tile_indices']:
+        yield HipsTileMeta(
+            order=pars['order'],
+            ipix=healpix_pixel_index,
+            frame=hips_survey.astropy_frame,
+            file_format=pars['tile_format'],
+        )
 
 
 @pytest.mark.parametrize('pars', TILE_FETCH_TEST_CASES)
@@ -33,15 +43,13 @@ TILE_FETCH_TEST_CASES = [
 def test_fetch_tiles(pars):
     hips_survey = HipsSurveyProperties.fetch(pars['url'])
 
-    tile_metas = []
-    for healpix_pixel_index in pars['tile_indices']:
-        tile_meta = HipsTileMeta(
-            order=pars['order'],
-            ipix=healpix_pixel_index,
-            frame=hips_survey.astropy_frame,
-            file_format=pars['tile_format'],
-        )
-        tile_metas.append(tile_meta)
+    tile_metas = list(make_tile_metas(hips_survey, pars))
 
-    tiles = fetch_tiles(tile_metas, hips_survey, progress_bar=pars['progress_bar'], fetch_package=pars['fetch_package'])
-    assert_allclose(tiles[0].data[0][5:10], [2101, 1680, 1532, 1625, 2131])
+    tiles = fetch_tiles(
+        tile_metas, hips_survey,
+        progress_bar=pars['progress_bar'],
+        fetch_package=pars['fetch_package'],
+    )
+
+    for idx, val in enumerate(pars['data']):
+        assert_allclose(tiles[idx].data[0][5], val)

--- a/hips/tiles/tests/test_fetch.py
+++ b/hips/tiles/tests/test_fetch.py
@@ -8,7 +8,7 @@ from ..tile import HipsTileMeta
 
 TILE_FETCH_TEST_CASES = [
     dict(
-        tile_indices=[69623, 69627, 69628, 69629, 69630, 69631],
+        tile_indices=[69623],
         tile_format='fits',
         order=7,
         url='http://alasky.unistra.fr/DSS/DSS2Merged/properties',
@@ -17,7 +17,7 @@ TILE_FETCH_TEST_CASES = [
         fetch_package='urllib'
     ),
     dict(
-        tile_indices=[69623, 69627, 69628, 69629, 69630, 69631],
+        tile_indices=[69623],
         tile_format='fits',
         order=7,
         url='http://alasky.unistra.fr/DSS/DSS2Merged/properties',

--- a/hips/tiles/tests/test_fetch.py
+++ b/hips/tiles/tests/test_fetch.py
@@ -1,0 +1,34 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from astropy.tests.helper import remote_data
+from numpy.testing import assert_allclose
+from ..fetch import HipsTileFetcher
+from ..survey import HipsSurveyProperties
+from ..tile import HipsTileMeta
+
+class TestHipsTileFetcher:
+    @classmethod
+    def setup_class(cls):
+        url = 'http://alasky.unistra.fr/DSS/DSS2Merged/properties'
+        hips_survey = HipsSurveyProperties.fetch(url)
+
+        tile_metas, tile_indices = [], [69623, 69627, 69628, 69629, 69630, 69631]
+        for healpix_pixel_index in tile_indices:
+            tile_meta = HipsTileMeta(
+                order=7,
+                ipix=healpix_pixel_index,
+                frame=hips_survey.astropy_frame,
+                file_format='fits',
+            )
+            tile_metas.append(tile_meta)
+
+        cls.fetcher = HipsTileFetcher(tile_metas, hips_survey, progress_bar=False)
+
+    @remote_data
+    def test_tiles(self):
+        tiles = self.fetcher.tiles
+        assert_allclose(tiles[0].data[0][5:10], [2101, 1680, 1532, 1625, 2131])
+
+    @remote_data
+    def test_tiles_aiohttp(self):
+        tiles = self.fetcher.tiles_aiohttp
+        assert_allclose(tiles[0].data[0][5:10], [2101, 1680, 1532, 1625, 2131])

--- a/hips/utils/testing.py
+++ b/hips/utils/testing.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Utilities for HiPS package testing.
 
 Not of use for users / outside this package.

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ extras_require = dict(
         'matplotlib>=2.0',
         'reproject>=0.3.1',
         'tqdm',
+        'aiohttp',
     ],
     develop=[
         'matplotlib>=2.0',
@@ -114,6 +115,7 @@ extras_require = dict(
         'pytest>=3.0',
         'mypy>=0.501',
         'tqdm',
+        'aiohttp',
     ],
 )
 


### PR DESCRIPTION
As the title states, HiPS tiles are now fetched asynchronously. I noted 4 seconds for tile fetching which previously took around 25 seconds at my end. For now, this is introduced in the `HipsPainter` class, but let me know if this needs to be refactored somewhere else.