### PR TITLE
Change from healpy to astropy-healpix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ distribute-*.tar.gz
 
 # Mac OSX
 .DS_Store
+
+v

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ env:
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - EVENT_TYPE='pull_request push'
-        - CONDA_DEPENDENCIES='healpy scikit-image Pillow reproject matplotlib tqdm aiohttp'
-        - PIP_DEPENDENCIES=''
+        - CONDA_DEPENDENCIES='astropy-healpix scikit-image Pillow reproject matplotlib tqdm aiohttp'
+#        - PIP_DEPENDENCIES='git+https://github.com/astropy/astropy-healpix.git#egg=astropy_healpix'
         - CONDA_CHANNELS='conda-forge astropy-ci-extras astropy'
         - SETUP_XVFB=True
         - DEBUG=True
@@ -56,7 +56,7 @@ matrix:
         # Check that install / tests work with minimal required dependencies
         - os: linux
           env: SETUP_CMD='test -V'
-               CONDA_DEPENDENCIES='healpy scikit-image Pillow'
+               CONDA_DEPENDENCIES='astropy-healpix scikit-image Pillow'
 
         # Try MacOS X
         - os: osx

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.2 (unreleased)
 ----------------
 
-- No changes yet
+- Change from ``healpy`` to ``astropy-healpix``. This means ``hips`` works on Windows!
 
 0.1
 ---

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
       # are in astropy-ci-extras. If your package uses either of these,
       # add the channels to CONDA_CHANNELS along with any other channels
       # you want to use.
-      CONDA_CHANNELS: "conda-forge astropy-ci-extras astropy openastronomy"
+      CONDA_CHANNELS: "conda-forge astropy-ci-extras"
 
   matrix:
 
@@ -42,4 +42,4 @@ install:
 build: false
 
 test_script:
-    - "%CMD_IN_ENV% python setup.py test"
+    - "%CMD_IN_ENV% python setup.py test --remote-data -V"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
       # For this package-template, we include examples of Cython modules,
       # so Cython is required for testing. If your package does not include
       # Cython code, you can set CONDA_DEPENDENCIES=''
-      CONDA_DEPENDENCIES: "reproject matplotlib"
+      CONDA_DEPENDENCIES: "astropy-healpix scikit-image Pillow reproject tqdm aiohttp matplotlib"
 
       # Conda packages for affiliated packages are hosted in channel
       # "astropy" while builds for astropy LTS with recent numpy versions
@@ -25,7 +25,7 @@ environment:
 
   matrix:
 
-      - PYTHON_VERSION: "3.5"
+      - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "stable"
         NUMPY_VERSION: "stable"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,9 +50,10 @@ setup_cfg = dict(conf.items('metadata'))
 
 # -- General configuration ----------------------------------------------------
 
+
 del intersphinx_mapping['scipy']
 del intersphinx_mapping['h5py']
-intersphinx_mapping['healpy'] = ('https://healpy.readthedocs.io/en/latest/', None)
+intersphinx_mapping['astropy-healpix'] = ('https://astropy-healpix.readthedocs.io/en/latest/', None)
 
 # By default, highlight as Python 3.
 highlight_language = 'python3'

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,6 +6,8 @@
 Installation
 ************
 
+The **hips** package works with Python 3.6 or later, on Linux, MacOS and Windows.
+
 Installing the latest stable version is possible either using pip or conda.
 
 How to install the latest development version is desribed on the :ref:`develop` page.
@@ -71,7 +73,7 @@ The ``hips`` package has the following requirements:
 * Python 3.6 or later!
 * `Numpy`_ 1.11 or later
 * `Astropy`_ 1.2 or later
-* `Healpy`_ 1.9 or later. (Older versions could work, but aren't tested.)
+* `astropy-healpix`_ 0.2 or later
 * `scikit-image`_ 0.12 or later. (Older versions could work, but aren't tested.)
 * `Pillow`_ 4.0 or later. (Older versions could work, but aren't tested.)
   Pillow is the friendly Python Imaging Library (``PIL``) fork, for JPEG and PNG tile I/O.

--- a/docs/references.txt
+++ b/docs/references.txt
@@ -1,6 +1,6 @@
 .. _matplotlib: https://matplotlib.org
 .. _Numpy: https://www.numpy.org
-.. _Healpy: https://healpy.readthedocs.io
+.. _astropy-healpix: https://astropy-healpix.readthedocs.io
 .. _scikit-image: http://scikit-image.org
 .. _Pillow: https://python-pillow.org/
 .. _HiPS paper: https://www.aanda.org/articles/aa/pdf/2015/06/aa26075-15.pdf

--- a/hips/conftest.py
+++ b/hips/conftest.py
@@ -8,24 +8,18 @@ from astropy.tests.pytest_plugins import *
 ## exceptions
 # enable_deprecations_as_exceptions()
 
-## Uncomment and customize the following lines to add/remove entries from
-## the list of packages for which version numbers are displayed when running
-## the tests. Making it pass for KeyError is essential in some cases when
-## the package uses other astropy affiliated packages.
-try:
-    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
-    PYTEST_HEADER_MODULES['healpy'] = 'healpy'
-    PYTEST_HEADER_MODULES['reproject'] = 'reproject'
-    PYTEST_HEADER_MODULES['matplotlib'] = 'matplotlib'
-    PYTEST_HEADER_MODULES.pop('h5py', None)
-    PYTEST_HEADER_MODULES.pop('Pandas', None)
-except KeyError:
-    pass
+PYTEST_HEADER_MODULES.clear()
+PYTEST_HEADER_MODULES.update([
+    ('numpy', 'numpy'),
+    ('Pillow', 'PIL'),
+    ('scikit-image', 'skimage'),
+    ('Astropy', 'astropy'),
+    ('astropy-healpix', 'astropy_healpix'),
+    ('aiohttp', 'aiohttp'),
+    ('reproject', 'reproject'),
+    ('matplotlib', 'matplotlib'),
+])
 
-## Uncomment the following lines to display the version number of the
-## package rather than the version number of Astropy in the top line when
-## running the tests.
-import os
 
 # This is to figure out the affiliated package version, rather than
 # using Astropy's
@@ -33,6 +27,8 @@ try:
     from .version import version
 except ImportError:
     version = 'dev'
+
+import os
 
 packagename = os.path.basename(os.path.dirname(__file__))
 TESTED_VERSIONS[packagename] = version

--- a/hips/draw/paint.py
+++ b/hips/draw/paint.py
@@ -6,7 +6,8 @@ from astropy.wcs.utils import proj_plane_pixel_scales
 from skimage.transform import ProjectiveTransform, warp
 from ..tiles import HipsSurveyProperties, HipsTile, HipsTileMeta, fetch_tiles
 from ..tiles.tile import compute_image_shape
-from ..utils import WCSGeometry, healpix_pixels_in_sky_image, hips_order_for_pixel_resolution
+from ..utils.wcs import WCSGeometry
+from ..utils.healpix import healpix_pixels_in_sky_image, hips_order_for_pixel_resolution
 
 __all__ = [
     'HipsPainter',

--- a/hips/draw/tests/test_ui.py
+++ b/hips/draw/tests/test_ui.py
@@ -68,7 +68,7 @@ def test_make_sky_image(tmpdir, pars):
     assert result.image.shape == pars['shape']
     assert result.image.dtype == pars['dtype']
     assert repr(result) == pars['repr']
-    assert_allclose(np.sum(result.image), pars['data_sum'])
+    assert_allclose(np.sum(result.image, dtype=float), pars['data_sum'])
     assert_allclose(result.image[200, 994], pars['data_1'])
     assert_allclose(result.image[200, 995], pars['data_2'])
     result.write_image(str(tmpdir / 'test.' + pars['file_format']))

--- a/hips/draw/ui.py
+++ b/hips/draw/ui.py
@@ -4,8 +4,8 @@ import numpy as np
 from PIL import Image
 from astropy.io import fits
 from typing import List, Union
+from ..utils.wcs import WCSGeometry
 from ..tiles import HipsSurveyProperties, HipsTile
-from ..utils import WCSGeometry
 from .paint import HipsPainter
 
 __all__ = [

--- a/hips/tiles/tile.py
+++ b/hips/tiles/tile.py
@@ -84,8 +84,8 @@ class HipsTileMeta:
     ( 264.375, -35.68533471), ( 270.   , -30.        )]>
     >>> tile_meta.tile_default_url
     'Norder3/Dir0/Npix450.fits'
-    >>> tile_meta.tile_default_path
-    PosixPath('Norder3/Dir0/Npix450.fits')
+    >>> tile_meta.tile_default_path.as_posix()
+    'Norder3/Dir0/Npix450.fits'
     """
 
     def __init__(self, order: int, ipix: int, file_format: str,
@@ -298,8 +298,8 @@ class HipsTile:
         elif fmt in {'jpg', 'png'}:
             with Image.open(bio) as image:
                 data = np.array(image)
-                # Flip tile to be consistent with FITS orientation
-                data = np.flipud(data)
+            # Flip tile to be consistent with FITS orientation
+            data = np.flipud(data)
         else:
             raise ValueError(f'Tile file format not supported: {fmt}. '
                              'Supported formats: fits, jpg, png')

--- a/hips/tiles/tile.py
+++ b/hips/tiles/tile.py
@@ -11,7 +11,7 @@ from astropy.utils.exceptions import AstropyWarning
 from astropy.io.fits.verify import VerifyWarning
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
-from ..utils import healpix_pixel_corners
+from ..utils.healpix import healpix_pixel_corners
 from .io import tile_default_url, tile_default_path
 
 __all__ = [

--- a/hips/utils/__init__.py
+++ b/hips/utils/__init__.py
@@ -5,5 +5,3 @@ Note that those are mostly for internal notes, if you use them from
 external scripts or packages at all, you should not expect stability
 from our side and it might be better if you copy over what you need.
 """
-from .wcs import *
-from .healpix import *

--- a/hips/utils/healpix.py
+++ b/hips/utils/healpix.py
@@ -9,9 +9,11 @@ from .wcs import WCSGeometry
 
 __all__ = [
     'healpix_order_to_npix',
-    'healpix_pixel_corners',
-    'healpix_pixels_in_sky_image',
     'hips_order_for_pixel_resolution',
+    'healpix_pixel_corners',
+
+    'healpix_pixels_in_sky_image',
+    'hips_tile_healpix_ipix_array',
 ]
 
 __doctest_skip__ = [
@@ -205,6 +207,8 @@ def nside_to_level(nside):
 
 
 # TODO: move to astropy-healpix
+# or maybe call this? `astropy.coordinates.frame_transform_graph.lookup_name(frame)`
+# See https://github.com/astropy/astropy-healpix/issues/56#issuecomment-336803290
 def make_frame(frame):
     if isinstance(frame, BaseCoordinateFrame):
         return frame

--- a/hips/utils/healpix.py
+++ b/hips/utils/healpix.py
@@ -14,7 +14,7 @@ Contributions welcome!
 from typing import Tuple
 from functools import lru_cache
 import numpy as np
-import healpy as hp
+from astropy_healpix import healpy as hp
 from astropy.coordinates import SkyCoord
 from .wcs import WCSGeometry
 

--- a/hips/utils/healpix.py
+++ b/hips/utils/healpix.py
@@ -1,31 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""HEALPix and HiPS utility functions.
-
-At the moment we use the following functions from ``healpy``:
-
-* compute HEALPix pixel indices in nested scheme: ``hp.ang2pix`` and ``hp.order2nside``
-* compute HEALPix pixel corners: ``hp.boundaries`` and ``hp.vec2ang``
-
-We would like to get rid of the dependency on ``healpy``
-and re-implement those functions here or in Astropy core.
-
-Contributions welcome!
-"""
-from typing import Tuple
+"""HEALPix and HiPS utility functions."""
 from functools import lru_cache
 import numpy as np
-from astropy_healpix import healpy as hp
-from astropy.coordinates import SkyCoord
+from astropy_healpix import HEALPix
+from astropy_healpix.core import level_to_nside
+from astropy.coordinates import SkyCoord, Angle, ICRS, Galactic, BaseCoordinateFrame
 from .wcs import WCSGeometry
 
 __all__ = [
     'healpix_order_to_npix',
-    'healpix_skycoord_to_theta_phi',
-    'healpix_theta_phi_to_skycoord',
-
     'healpix_pixel_corners',
     'healpix_pixels_in_sky_image',
-
     'hips_order_for_pixel_resolution',
 ]
 
@@ -34,25 +19,10 @@ __doctest_skip__ = [
     'healpix_pixels_in_sky_image',
 ]
 
-HIPS_HEALPIX_NEST = True
-"""HiPS always uses the nested HEALPix pixel numbering scheme."""
-
 
 def healpix_order_to_npix(order: int) -> int:
     """HEALPix order to npix."""
-    return hp.nside2npix(hp.order2nside(order))
-
-
-def healpix_skycoord_to_theta_phi(skycoord: SkyCoord) -> Tuple[float, float]:
-    """Convert SkyCoord to theta / phi as used in healpy."""
-    theta = np.pi / 2 - skycoord.data.lat.radian
-    phi = skycoord.data.lon.radian
-    return theta, phi
-
-
-def healpix_theta_phi_to_skycoord(theta: float, phi: float, frame: str) -> SkyCoord:
-    """Convert theta/phi as used in healpy to SkyCoord."""
-    return SkyCoord(phi, np.pi / 2 - theta, unit='radian', frame=frame)
+    return HEALPix(nside=2 ** order, order='nested').npix
 
 
 def healpix_pixel_corners(order: int, ipix: int, frame: str) -> SkyCoord:
@@ -81,10 +51,9 @@ def healpix_pixel_corners(order: int, ipix: int, frame: str) -> SkyCoord:
     corners : `~astropy.coordinates.SkyCoord`
         Sky coordinates (array of length 4).
     """
-    nside = hp.order2nside(order)
-    boundary_coords = hp.boundaries(nside, ipix, nest=HIPS_HEALPIX_NEST)
-    theta, phi = hp.vec2ang(np.transpose(boundary_coords))
-    return healpix_theta_phi_to_skycoord(theta, phi, frame)
+    frame = make_frame(frame)
+    hp = HEALPix(nside=2 ** order, order='nested', frame=frame)
+    return hp.boundaries_skycoord(ipix, step=1)[0]
 
 
 def healpix_pixels_in_sky_image(geometry: WCSGeometry, order: int, healpix_frame: str) -> np.ndarray:
@@ -114,7 +83,7 @@ def healpix_pixels_in_sky_image(geometry: WCSGeometry, order: int, healpix_frame
     --------
     >>> from astropy.coordinates import SkyCoord
     >>> from hips import WCSGeometry
-    >>> from hips.utils import healpix_pixels_in_sky_image
+    >>> from hips.utils.healpix import healpix_pixels_in_sky_image
     >>> skycoord = SkyCoord(10, 20, unit="deg")
     >>> geometry = WCSGeometry.create(
     ...     skydir=skycoord, shape=(10, 20),
@@ -124,10 +93,9 @@ def healpix_pixels_in_sky_image(geometry: WCSGeometry, order: int, healpix_frame
     >>> healpix_pixels_in_sky_image(geometry, order=3, healpix_frame='galactic')
     array([321, 611, 614, 615, 617, 618, 619, 620, 621, 622])
     """
-    nside = hp.order2nside(order)
-    pixel_coords = geometry.pixel_skycoords.transform_to(healpix_frame)
-    theta, phi = healpix_skycoord_to_theta_phi(pixel_coords)
-    ipix = hp.ang2pix(nside, theta, phi, nest=HIPS_HEALPIX_NEST)
+    hp = HEALPix(nside=2 ** order, order='nested', frame=healpix_frame)
+    skycoord = geometry.pixel_skycoords  # .transform_to(healpix_frame)
+    ipix = hp.skycoord_to_healpix(skycoord)
     return np.unique(ipix)
 
 
@@ -146,16 +114,9 @@ def hips_order_for_pixel_resolution(tile_width: int, resolution: float) -> int:
     candidate_tile_order : int
         Best HiPS tile order
     """
-    tile_order = np.log2(tile_width)
-    full_sphere_area = 4 * np.pi * np.square(180 / np.pi)
-    # 29 is the maximum order supported by healpy and 3 is the minimum order
-    for candidate_tile_order in range(3, 29 + 1):
-        tile_resolution = np.sqrt(full_sphere_area / 12 / 4 ** (candidate_tile_order + tile_order))
-        # Finding the smaller tile order with a resolution equal to or better than geometric resolution
-        if tile_resolution <= resolution:
-            break
-
-    return candidate_tile_order
+    resolution = Angle(resolution, unit='deg')
+    nside = pixel_resolution_to_nside(resolution * tile_width, round='up')
+    return nside_to_level(nside)
 
 
 @lru_cache(maxsize=None)
@@ -208,3 +169,51 @@ def hips_tile_healpix_ipix_array(shift_order: int) -> np.ndarray:
         data2 = np.repeat(data2, repeats, axis=1)
 
         return data1 + data2
+
+
+# TODO: remove this function and call the one in `astropy_healpix`
+# as soon as astropy-healpix v0.3 is released
+def pixel_resolution_to_nside(resolution, round='nearest'):
+    resolution = Angle(resolution).radian
+    pixel_area = resolution * resolution
+    npix = 4 * np.pi / pixel_area
+    nside = np.sqrt(npix / 12)
+
+    # Now we have to round to the closest ``nside``
+    # Since ``nside`` must be a power of two,
+    # we first compute the corresponding ``level = log2(nside)`
+    # round the level and then go back to nside
+    level = np.log2(nside)
+
+    if round == 'up':
+        level = np.array(level, dtype=int) + 1
+    elif round == 'nearest':
+        level = np.array(level + 0.5, dtype=int)
+    elif round == 'down':
+        level = np.array(level, dtype=int)
+    else:
+        raise ValueError('Invalid value for round: {!r}'.format(round))
+
+    return level_to_nside(np.clip(level, 0, None))
+
+
+# TODO: move to astropy-healpix
+# Call from above as: HEALPix(nside, order='nested').level
+def nside_to_level(nside):
+    level = np.log2(nside)
+    return np.round(level).astype(int)
+
+
+# TODO: move to astropy-healpix
+def make_frame(frame):
+    if isinstance(frame, BaseCoordinateFrame):
+        return frame
+    elif isinstance(frame, str):
+        if frame == 'icrs':
+            return ICRS()
+        elif frame == 'galactic':
+            return Galactic()
+        else:
+            raise ValueError(f'Invalid value for frame: {frame!r}')
+    else:
+        raise TypeError(f'Invalid type for frame: {type(frame)}')

--- a/hips/utils/tests/test_healpix.py
+++ b/hips/utils/tests/test_healpix.py
@@ -12,64 +12,64 @@ from ..healpix import (
 )
 
 
-# def test_order_to_npix():
-#     assert healpix_order_to_npix(3) == 768
-#
-#
-# def test_healpix_pixel_corners():
-#     """
-#     These HEALPix corner values were verified through Aladin Lite with the "Show
-#     healpix grid" option turned on. More information can be found on this GitHub
-#     issue: https://github.com/healpy/healpy/issues/393#issuecomment-305994042
-#     """
-#     corners = healpix_pixel_corners(order=3, ipix=450, frame='icrs')
-#
-#     assert_allclose(corners.ra.deg, [264.375, 258.75, 264.375, 270.])
-#     assert_allclose(corners.dec.deg, [-24.624318, -30., -35.685335, -30.])
-#
-#
-# @pytest.mark.parametrize('pars', [
-#     dict(frame='galactic', ipix=[269, 270, 271, 280, 282, 283, 292, 293, 295, 304, 305, 306]),
-#     dict(frame='icrs', ipix=[448, 449, 450, 451, 454, 456, 457, 460, 661, 663, 669]),
-# ])
-# def test_wcs_healpix_pixel_indices(pars):
-#     geometry = make_test_wcs_geometry()
-#     healpix_pixel_indices = healpix_pixels_in_sky_image(geometry, order=3, healpix_frame=pars['frame'])
-#     assert list(healpix_pixel_indices) == pars['ipix']
-#
-#
-# @pytest.mark.parametrize('pars', [
-#     dict(tile_width=512, resolution=0.01232, resolution_res=0.06395791924665553, order=4),
-#     dict(tile_width=256, resolution=0.0016022, resolution_res=0.003997369952915971, order=8),
-#     dict(tile_width=128, resolution=0.00009032, resolution_res=0.00012491781102862408, order=13),
-# ])
-# def test_get_hips_order_for_resolution(pars):
-#     hips_order = hips_order_for_pixel_resolution(pars['tile_width'], pars['resolution'])
-#     assert hips_order == pars['order']
-#     hips_resolution = hp.nside2resol(hp.order2nside(hips_order))
-#     assert_allclose(hips_resolution, pars['resolution_res'])
-#
-#
-# def test_hips_tile_healpix_ipix_array():
-#     ipix = hips_tile_healpix_ipix_array(shift_order=1)
-#     ipix_expected = [
-#         [0, 1],
-#         [2, 3],
-#     ]
-#     assert ipix.shape == (2, 2)
-#     assert_equal(ipix, ipix_expected)
-#
-#     ipix = hips_tile_healpix_ipix_array(shift_order=2)
-#     ipix_expected = [
-#         [0, 1, 4, 5],
-#         [2, 3, 6, 7],
-#         [8, 9, 12, 13],
-#         [10, 11, 14, 15],
-#     ]
-#     assert ipix.shape == (4, 4)
-#     assert_equal(ipix, ipix_expected)
-#
-#     ipix = hips_tile_healpix_ipix_array(shift_order=3)
-#     assert ipix.shape == (8, 8)
-#     assert ipix[0, 0] == 0
-#     assert ipix[-1, -1] == 63
+def test_order_to_npix():
+    assert healpix_order_to_npix(3) == 768
+
+
+def test_healpix_pixel_corners():
+    """
+    These HEALPix corner values were verified through Aladin Lite with the "Show
+    healpix grid" option turned on. More information can be found on this GitHub
+    issue: https://github.com/healpy/healpy/issues/393#issuecomment-305994042
+    """
+    corners = healpix_pixel_corners(order=3, ipix=450, frame='icrs')
+
+    assert_allclose(corners.ra.deg, [264.375, 258.75, 264.375, 270.])
+    assert_allclose(corners.dec.deg, [-24.624318, -30., -35.685335, -30.])
+
+
+@pytest.mark.parametrize('pars', [
+    dict(frame='galactic', ipix=[269, 270, 271, 280, 282, 283, 292, 293, 295, 304, 305, 306]),
+    dict(frame='icrs', ipix=[448, 449, 450, 451, 454, 456, 457, 460, 661, 663, 669]),
+])
+def test_wcs_healpix_pixel_indices(pars):
+    geometry = make_test_wcs_geometry()
+    healpix_pixel_indices = healpix_pixels_in_sky_image(geometry, order=3, healpix_frame=pars['frame'])
+    assert list(healpix_pixel_indices) == pars['ipix']
+
+
+@pytest.mark.parametrize('pars', [
+    dict(tile_width=512, resolution=0.01232, resolution_res=0.06395791924665553, order=4),
+    dict(tile_width=256, resolution=0.0016022, resolution_res=0.003997369952915971, order=8),
+    dict(tile_width=128, resolution=0.00009032, resolution_res=0.00012491781102862408, order=13),
+])
+def test_get_hips_order_for_resolution(pars):
+    hips_order = hips_order_for_pixel_resolution(pars['tile_width'], pars['resolution'])
+    assert hips_order == pars['order']
+    hips_resolution = hp.nside2resol(hp.order2nside(hips_order))
+    assert_allclose(hips_resolution, pars['resolution_res'])
+
+
+def test_hips_tile_healpix_ipix_array():
+    ipix = hips_tile_healpix_ipix_array(shift_order=1)
+    ipix_expected = [
+        [0, 1],
+        [2, 3],
+    ]
+    assert ipix.shape == (2, 2)
+    assert_equal(ipix, ipix_expected)
+
+    ipix = hips_tile_healpix_ipix_array(shift_order=2)
+    ipix_expected = [
+        [0, 1, 4, 5],
+        [2, 3, 6, 7],
+        [8, 9, 12, 13],
+        [10, 11, 14, 15],
+    ]
+    assert ipix.shape == (4, 4)
+    assert_equal(ipix, ipix_expected)
+
+    ipix = hips_tile_healpix_ipix_array(shift_order=3)
+    assert ipix.shape == (8, 8)
+    assert ipix[0, 0] == 0
+    assert ipix[-1, -1] == 63

--- a/hips/utils/tests/test_healpix.py
+++ b/hips/utils/tests/test_healpix.py
@@ -12,64 +12,64 @@ from ..healpix import (
 )
 
 
-def test_order_to_npix():
-    assert healpix_order_to_npix(3) == 768
-
-
-def test_healpix_pixel_corners():
-    """
-    These HEALPix corner values were verified through Aladin Lite with the "Show
-    healpix grid" option turned on. More information can be found on this GitHub
-    issue: https://github.com/healpy/healpy/issues/393#issuecomment-305994042
-    """
-    corners = healpix_pixel_corners(order=3, ipix=450, frame='icrs')
-
-    assert_allclose(corners.ra.deg, [264.375, 258.75, 264.375, 270.])
-    assert_allclose(corners.dec.deg, [-24.624318, -30., -35.685335, -30.])
-
-
-@pytest.mark.parametrize('pars', [
-    dict(frame='galactic', ipix=[269, 270, 271, 280, 282, 283, 292, 293, 295, 304, 305, 306]),
-    dict(frame='icrs', ipix=[448, 449, 450, 451, 454, 456, 457, 460, 661, 663, 669]),
-])
-def test_wcs_healpix_pixel_indices(pars):
-    geometry = make_test_wcs_geometry()
-    healpix_pixel_indices = healpix_pixels_in_sky_image(geometry, order=3, healpix_frame=pars['frame'])
-    assert list(healpix_pixel_indices) == pars['ipix']
-
-
-@pytest.mark.parametrize('pars', [
-    dict(tile_width=512, resolution=0.01232, resolution_res=0.06395791924665553, order=4),
-    dict(tile_width=256, resolution=0.0016022, resolution_res=0.003997369952915971, order=8),
-    dict(tile_width=128, resolution=0.00009032, resolution_res=0.00012491781102862408, order=13),
-])
-def test_get_hips_order_for_resolution(pars):
-    hips_order = hips_order_for_pixel_resolution(pars['tile_width'], pars['resolution'])
-    assert hips_order == pars['order']
-    hips_resolution = hp.nside2resol(hp.order2nside(hips_order))
-    assert_allclose(hips_resolution, pars['resolution_res'])
-
-
-def test_hips_tile_healpix_ipix_array():
-    ipix = hips_tile_healpix_ipix_array(shift_order=1)
-    ipix_expected = [
-        [0, 1],
-        [2, 3],
-    ]
-    assert ipix.shape == (2, 2)
-    assert_equal(ipix, ipix_expected)
-
-    ipix = hips_tile_healpix_ipix_array(shift_order=2)
-    ipix_expected = [
-        [0, 1, 4, 5],
-        [2, 3, 6, 7],
-        [8, 9, 12, 13],
-        [10, 11, 14, 15],
-    ]
-    assert ipix.shape == (4, 4)
-    assert_equal(ipix, ipix_expected)
-
-    ipix = hips_tile_healpix_ipix_array(shift_order=3)
-    assert ipix.shape == (8, 8)
-    assert ipix[0, 0] == 0
-    assert ipix[-1, -1] == 63
+# def test_order_to_npix():
+#     assert healpix_order_to_npix(3) == 768
+#
+#
+# def test_healpix_pixel_corners():
+#     """
+#     These HEALPix corner values were verified through Aladin Lite with the "Show
+#     healpix grid" option turned on. More information can be found on this GitHub
+#     issue: https://github.com/healpy/healpy/issues/393#issuecomment-305994042
+#     """
+#     corners = healpix_pixel_corners(order=3, ipix=450, frame='icrs')
+#
+#     assert_allclose(corners.ra.deg, [264.375, 258.75, 264.375, 270.])
+#     assert_allclose(corners.dec.deg, [-24.624318, -30., -35.685335, -30.])
+#
+#
+# @pytest.mark.parametrize('pars', [
+#     dict(frame='galactic', ipix=[269, 270, 271, 280, 282, 283, 292, 293, 295, 304, 305, 306]),
+#     dict(frame='icrs', ipix=[448, 449, 450, 451, 454, 456, 457, 460, 661, 663, 669]),
+# ])
+# def test_wcs_healpix_pixel_indices(pars):
+#     geometry = make_test_wcs_geometry()
+#     healpix_pixel_indices = healpix_pixels_in_sky_image(geometry, order=3, healpix_frame=pars['frame'])
+#     assert list(healpix_pixel_indices) == pars['ipix']
+#
+#
+# @pytest.mark.parametrize('pars', [
+#     dict(tile_width=512, resolution=0.01232, resolution_res=0.06395791924665553, order=4),
+#     dict(tile_width=256, resolution=0.0016022, resolution_res=0.003997369952915971, order=8),
+#     dict(tile_width=128, resolution=0.00009032, resolution_res=0.00012491781102862408, order=13),
+# ])
+# def test_get_hips_order_for_resolution(pars):
+#     hips_order = hips_order_for_pixel_resolution(pars['tile_width'], pars['resolution'])
+#     assert hips_order == pars['order']
+#     hips_resolution = hp.nside2resol(hp.order2nside(hips_order))
+#     assert_allclose(hips_resolution, pars['resolution_res'])
+#
+#
+# def test_hips_tile_healpix_ipix_array():
+#     ipix = hips_tile_healpix_ipix_array(shift_order=1)
+#     ipix_expected = [
+#         [0, 1],
+#         [2, 3],
+#     ]
+#     assert ipix.shape == (2, 2)
+#     assert_equal(ipix, ipix_expected)
+#
+#     ipix = hips_tile_healpix_ipix_array(shift_order=2)
+#     ipix_expected = [
+#         [0, 1, 4, 5],
+#         [2, 3, 6, 7],
+#         [8, 9, 12, 13],
+#         [10, 11, 14, 15],
+#     ]
+#     assert ipix.shape == (4, 4)
+#     assert_equal(ipix, ipix_expected)
+#
+#     ipix = hips_tile_healpix_ipix_array(shift_order=3)
+#     assert ipix.shape == (8, 8)
+#     assert ipix[0, 0] == 0
+#     assert ipix[-1, -1] == 63

--- a/hips/utils/tests/test_healpix.py
+++ b/hips/utils/tests/test_healpix.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 from numpy.testing import assert_allclose, assert_equal
-import healpy as hp
+from astropy_healpix import healpy as hp
 from ..testing import make_test_wcs_geometry
 from ..healpix import (
     healpix_order_to_npix,

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ package_info['package_data'][PACKAGENAME].extend(c_files)
 install_requires = [
     'numpy>=1.11',
     'astropy>=1.3',
-    'healpy>=1.9',
+    'astropy-healpix',
     'scikit-image',
     'Pillow',
 ]


### PR DESCRIPTION
This is a first quick attempt to change the `hips` package from `healpy` over to the to-be Astropy healpix package (http://healpix.readthedocs.io/). The main motivation for the change is to support Windows, another motivation is to have an easier-to-install dependency (or no dependency at all if this gets merged as `astropy.healpix` into the core at some point).

This pull request is work in progress, it should only be merged after there has been a release and a conda package exists for the Astropy healpix package.

In addition, I'd like to remove `hips/utils/healpix.py` and change the callers to use the main Astropy healpix API, not the healpy-compatible API, and the dependency declaration in `setup.py` as well as the install docs need to be updated.

@astrofrog - For now, I see two issues when running the tests:
https://gist.github.com/cdeil/a81421e94df6ed4cd732ddcf61c4174a

1. We are passing 2-dim arrays, but currently only 1-dim arrays are supported. This is issue https://github.com/cdeil/healpix/issues/21 . This is a blocker for making the change.
2. We are calling `healpy.boundaries` which is still missing in `healpix.healpy`. This is issue https://github.com/cdeil/healpix/issues/23 . This means it's not a drop-in replacement, but we should change to `healpix_boundaries_lonlat` anyways, so not really needed.