### PR TITLE
Update readthedocs.yml to use astropy-healpix

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -2,19 +2,16 @@ name: hips
 
 channels:
     - conda-forge
-    - astropy
 
 dependencies:
     - python=3.6
     - numpy
     - astropy
-    - healpy
+    - astropy-healpix
     - reproject
     - matplotlib
     - tqdm
     - aiohttp
-    # There's a problem with Sphinx 1.6 with astropy-helpers
-    # For now, we pin the Sphinx version to something that works
-    - sphinx==1.5.6
+    - sphinx
     - pip:
         - sphinx_rtd_theme

--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,8 @@ Project status
 * .. image:: http://img.shields.io/travis/hipspy/hips.svg?branch=master
     :target: https://travis-ci.org/hipspy/hips
     :alt: Test Status travis-ci
-* .. image:: https://ci.appveyor.com/api/projects/status/9npru9xyu0ex32ln?svg=true
-    :target: https://ci.appveyor.com/project/cdeil/hips/branch/master
+* .. image:: https://ci.appveyor.com/api/projects/status/spq5jvtvb8ra263n/branch/master?svg=true
+    :target: https://ci.appveyor.com/project/cdeil/hips-19275o3fsp6drby/branch/master
     :alt: Test Status Appveyor
 * .. image:: https://img.shields.io/coveralls/hipspy/hips.svg
     :target: https://coveralls.io/r/hipspy/hips

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,5 +2,5 @@ conda:
   file: .rtd-environment.yml
 
 python:
-   version: 3.5
+   version: 3.6
    setup_py_install: true


### PR DESCRIPTION
This PR is updating readthedocs.yml to use astropy-healpix .

Really the main thing here is to see if the build / test works on Windows (see #3).