### PR TITLE
Update astropy-helpers to v3.0.1

### DIFF
--- a/hips/tiles/tile.py
+++ b/hips/tiles/tile.py
@@ -21,6 +21,7 @@ __all__ = [
 
 __doctest_skip__ = [
     'HipsTile',
+    'HipsTileMeta',
 ]
 
 


### PR DESCRIPTION
This is an automated update of the astropy-helpers submodule to v3.0.1. This includes both the update of the astropy-helpers sub-module, and the ``ah_bootstrap.py`` file, if needed. 

A full list of changes can be found in the [changelog](https://github.com/astropy/astropy-helpers/blob/v3.0.1/CHANGES.rst). 

*This is intended to be helpful, but if you would prefer to manage these updates yourself, or if you notice any issues with this automated update, please let @bsipocz or @astrofrog know!* 

Along with with the astropy core release v3.0, we have also started to release astropy-helpers v3.0.x versions. Similarly to the core package, these require Python 3.5+. We will open automated update PRs with astropy-helpers v3.0.x only for packages that specifically opt in for it when they start supporting Python 3.5+ only. Please let @bsipocz or @astrofrog know or add your package to the list in https://github.com/astropy/astropy-procedures/blob/master/update-affiliated/helpers_3.py