### PR TITLE
Use dict (now ordered in Python 3.6+

### DIFF
--- a/hips/draw/healpix.py
+++ b/hips/draw/healpix.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from pathlib import Path
-from collections import OrderedDict
 import numpy as np
 from astropy_healpix import healpy as hp
 from ..tiles import HipsTile, HipsTileMeta, HipsSurveyProperties
@@ -81,10 +80,11 @@ def healpix_to_hips(hpx_data, tile_width, base_path, file_format='fits'):
         tile.write(filename=filename)
 
 
-    data = OrderedDict()
-    data['hips_tile_format'] = file_format
-    data['hips_tile_width'] = tile_width
-    data['hips_frame'] = tile.meta.frame
+    data = {
+        'hips_tile_format': file_format,
+        'hips_tile_width': tile_width,
+        'hips_frame': tile.meta.frame,
+    }
 
     properties = HipsSurveyProperties(data=data)
     properties.write(base_path / 'properties')

--- a/hips/tiles/fetch.py
+++ b/hips/tiles/fetch.py
@@ -79,7 +79,7 @@ def fetch_tiles(tile_metas: List[HipsTileMeta], hips_survey: HipsSurveyPropertie
 
     # Sort tiles to match the tile_meta list
     # TODO: this doesn't seem like a great solution.
-    # Use OrderedDict instead?
+    # Use dict instead?
     out = []
     for tile_meta in tile_metas:
         for tile in tiles:

--- a/hips/tiles/survey.py
+++ b/hips/tiles/survey.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from collections import OrderedDict
 from io import StringIO
 from csv import DictWriter
 from pathlib import Path
@@ -24,7 +23,7 @@ class HipsSurveyProperties:
 
     Parameters
     ----------
-    data : `~collections.OrderedDict`
+    data : `dict`
         HiPS survey properties
 
     Examples
@@ -35,14 +34,14 @@ class HipsSurveyProperties:
     >>> hips_survey_property.base_url
     'http://alasky.u-strasbg.fr/DSS/DSS2Merged'
     """
-    hips_to_astropy_frame_mapping = OrderedDict([
-        ('equatorial', 'icrs'),
-        ('galactic', 'galactic'),
-        ('ecliptic', 'ecliptic'),
-    ])
+    hips_to_astropy_frame_mapping = {
+        'equatorial': 'icrs',
+        'galactic': 'galactic',
+        'ecliptic': 'ecliptic',
+    }
     """HIPS to Astropy SkyCoord frame string mapping."""
 
-    def __init__(self, data: OrderedDict) -> None:
+    def __init__(self, data: dict) -> None:
         self.data = data
 
     @classmethod
@@ -101,7 +100,7 @@ class HipsSurveyProperties:
         url : str
             Properties URL of HiPS
         """
-        data: OrderedDict = OrderedDict()
+        data = {}
         for line in text.split('\n'):
             # Skip empty or comment lines
             if line == '' or line.startswith('#'):


### PR DESCRIPTION
Python dicts are ordered since Python 3.6, and it will stay that way (see [here](https://mail.python.org/pipermail/python-dev/2017-December/151283.html)).
So removing `collections.OrderedDict` by `dict`.