### PR TITLE
Add overwrite option in write_image function for FITS files

### DIFF
--- a/hips/draw/tests/test_ui.py
+++ b/hips/draw/tests/test_ui.py
@@ -74,12 +74,8 @@ def test_make_sky_image(tmpdir, pars):
     result.write_image(str(tmpdir / 'test.' + pars['file_format']), False)
 
     # Try and overwrite the image.
-    if pars['file_format'] == 'fits':
-        with pytest.raises(OSError):
-            result.write_image(str(tmpdir / 'test.' + pars['file_format']), False)
-    else:
-        with pytest.raises(FileExistsError):
-            result.write_image(str(tmpdir / 'test.' + pars['file_format']), False)
+    with pytest.raises(FileExistsError):
+        result.write_image(str(tmpdir / 'test.' + pars['file_format']), False)
 
     result.plot()
     result.report()

--- a/hips/draw/tests/test_ui.py
+++ b/hips/draw/tests/test_ui.py
@@ -71,6 +71,15 @@ def test_make_sky_image(tmpdir, pars):
     assert_allclose(np.sum(result.image, dtype=float), pars['data_sum'])
     assert_allclose(result.image[200, 994], pars['data_1'])
     assert_allclose(result.image[200, 995], pars['data_2'])
-    result.write_image(str(tmpdir / 'test.' + pars['file_format']))
+    result.write_image(str(tmpdir / 'test.' + pars['file_format']), False)
+
+    # Try and overwrite the image.
+    if pars['file_format'] == 'fits':
+        with pytest.raises(OSError):
+            result.write_image(str(tmpdir / 'test.' + pars['file_format']), False)
+    else:
+        with pytest.raises(FileExistsError):
+            result.write_image(str(tmpdir / 'test.' + pars['file_format']), False)
+
     result.plot()
     result.report()

--- a/hips/draw/ui.py
+++ b/hips/draw/ui.py
@@ -111,15 +111,15 @@ class HipsDrawResult:
         overwrite : bool
             Overwrite the output file, if it exists
         """
+        if overwrite == False and Path(filename).exists():
+            raise FileExistsError(f"File {filename} already exists.")
+
         if self.tile_format == 'fits':
             hdu = fits.PrimaryHDU(data=self.image, header=self.geometry.fits_header)
-            hdu.writeto(filename, overwrite=overwrite)
+            hdu.writeto(filename)
         else:
             image = Image.fromarray(self.image)
-            if overwrite == False and Path(filename).exists():
-                raise FileExistsError
-            else:
-                image.save(filename)
+            image.save(filename)
 
     def plot(self) -> None:
         """Plot the all sky image and overlay HiPS tile outlines.

--- a/hips/draw/ui.py
+++ b/hips/draw/ui.py
@@ -100,17 +100,19 @@ class HipsDrawResult:
             stats=painter._stats,
         )
 
-    def write_image(self, filename: str) -> None:
+    def write_image(self, filename: str, overwrite: bool = False) -> None:
         """Write image to file.
 
         Parameters
         ----------
         filename : str
             Filename
+        overwrite : bool
+            Overwrite the output file, if it exists
         """
         if self.tile_format == 'fits':
             hdu = fits.PrimaryHDU(data=self.image, header=self.geometry.fits_header)
-            hdu.writeto(filename)
+            hdu.writeto(filename, overwrite)
         else:
             image = Image.fromarray(self.image)
             image.save(filename)

--- a/hips/draw/ui.py
+++ b/hips/draw/ui.py
@@ -2,6 +2,7 @@
 """The high-level end user interface (UI)."""
 import numpy as np
 from PIL import Image
+from pathlib import Path
 from astropy.io import fits
 from typing import List, Union
 from ..utils.wcs import WCSGeometry
@@ -112,10 +113,13 @@ class HipsDrawResult:
         """
         if self.tile_format == 'fits':
             hdu = fits.PrimaryHDU(data=self.image, header=self.geometry.fits_header)
-            hdu.writeto(filename, overwrite)
+            hdu.writeto(filename, overwrite=overwrite)
         else:
             image = Image.fromarray(self.image)
-            image.save(filename)
+            if overwrite == False and Path(filename).exists():
+                raise FileExistsError
+            else:
+                image.save(filename)
 
     def plot(self) -> None:
         """Plot the all sky image and overlay HiPS tile outlines.


### PR DESCRIPTION
Following issue #127, this PR adds the `overwrite` parameter to `write_image` function, which defaults to `False`. For now, this parameter only works with FITS files, I'm not sure what's the default behavior of PIL for JPG and PNG files.

@cdeil - Should I include a test case for this by writing a same file twice?