### PR TITLE
TestHipsSurveyPropertiesList.test_table fail

### DIFF
--- a/hips/tiles/survey.py
+++ b/hips/tiles/survey.py
@@ -296,10 +296,11 @@ class HipsSurveyPropertiesList:
         rows = [properties.data for properties in self.data]
         fieldnames = sorted({key for row in rows for key in row})
         buffer = StringIO()
-        writer = DictWriter(buffer, fieldnames=fieldnames)
+        writer = DictWriter(buffer, fieldnames=fieldnames, dialect='unix')
         writer.writeheader()
         writer.writerows(rows)
-        return Table.read(buffer.getvalue(), format='ascii.csv', guess=False)
+        txt = buffer.getvalue()
+        return Table.read(txt, format='ascii.csv', guess=False, fast_reader=False)
 
     def from_name(self, name: str) -> 'HipsSurveyProperties':
         """Return a matching HiPS survey (`HipsSurveyProperties`)."""


### PR DESCRIPTION
There's a fail in `TestHipsSurveyPropertiesList.test_table`:
https://travis-ci.org/hipspy/hips/jobs/467627256#L3839

I see the fail locally as well with latest Astropy.

It comes from here:
https://github.com/hipspy/hips/blob/e870e5c97a136810e857c676a65e6beb2bf1804f/hips/tiles/survey.py#L287-L302

I'll look into this issue tomorrow and fix it somehow.