### PR TITLE
Feature/coaddmask

### DIFF
--- a/hips/draw/paint.py
+++ b/hips/draw/paint.py
@@ -190,6 +190,8 @@ class HipsPainter:
     def draw_all_tiles(self):
         """Make an empty sky image and draw all the tiles."""
         image = self._make_empty_sky_image()
+        """Make a coadd mask"""
+        coadds = self._make_empty_sky_image()
         if self.progress_bar:
             from tqdm import tqdm
             tiles = tqdm(self.draw_tiles, desc='Drawing tiles')
@@ -198,12 +200,19 @@ class HipsPainter:
 
         for tile in tiles:
             tile_image = self.warp_image(tile)
-            # TODO: put better algorithm here instead of summing pixels
-            # this can lead to pixels that are painted twice and become to bright
             image += tile_image
+            # The mask has a value of 1 wherever there is positive flux
+            # mask = image > 0.0
+            mask = np.where(tile_image > 0.0, 1, 0)
+            coadds += mask
+
+        # import matplotlib.pyplot as plt
+        # plt.imshow(coadds)
+
+        # TODO: use the mask to interpolate across the healpix seams rather than divide
 
         # Store the result
-        self.float_image = image
+        self.float_image = np.divide(image, coadds, where=coadds != 0)
 
     def plot_mpl_hips_tile_grid(self) -> None:
         """Plot output image and HiPS grid with matplotlib.

--- a/hips/draw/ui.py
+++ b/hips/draw/ui.py
@@ -116,10 +116,10 @@ class HipsDrawResult:
 
         if self.tile_format == 'fits':
             hdu = fits.PrimaryHDU(data=self.image, header=self.geometry.fits_header)
-            hdu.writeto(filename)
+            hdu.writeto(filename, overwrite=overwrite)
         else:
             image = Image.fromarray(self.image)
-            image.save(filename)
+            image.save(filename,j, overwrite=overwrite)
 
     def plot(self, show_grid: bool = False) -> None:
         """Plot the all sky image and overlay HiPS tile outlines.


### PR DESCRIPTION
Divide the output image by a coadd mask (each pixel is the number of input images, or tiles, that went into the sum) in order eliminate the bright seams between the healpix tiles. The result is better, but now the flux in the seams is somewhat depressed compared to the idea.