### PR TITLE
Convert image tiles to native byte order before warping

### DIFF
--- a/hips/draw/paint.py
+++ b/hips/draw/paint.py
@@ -136,7 +136,9 @@ class HipsPainter:
     def warp_image(self, tile: HipsTile) -> np.ndarray:
         """Warp a HiPS tile and a sky image."""
         return warp(
-            tile.data,
+            # FITS images are big endian,
+            # but warp() only supports native byte order.
+            tile.data.astype(tile.data.dtype.newbyteorder('=')),
             self.projection(tile),
             output_shape=self.geometry.shape,
             preserve_range=True,


### PR DESCRIPTION
FITS images are big-endian, but warp() only supports native byte order. Convert image tiles to native byte order before warping.

Fixes #150.